### PR TITLE
Add missing income frequency codes to map

### DIFF
--- a/lib/aca_entities/atp/types.rb
+++ b/lib/aca_entities/atp/types.rb
@@ -37,11 +37,12 @@ module AcaEntities
       FrequencyCodeMap = { "annually" => "yearly",
                            'biweekly' => 'biweekly',
                            'daily' => 'daily',
-                           'half_yearly' => 'half_yearly',
+                           'semiannually' => 'half_yearly',
                            'monthly' => 'monthly',
                            'quarterly' => 'quarterly',
                            'weekly' => 'weekly',
-                           'hourly' => 'hourly' }.freeze
+                           'hourly' => 'hourly',
+                           'once' => 'yearly' }.freeze
 
       DeductionKinds = {
         'Alimony' => 'alimony_paid',


### PR DESCRIPTION
Map 'semiannually' to 'half_yearly' and 'once' to 'yearly' in ATP income frequency code map.