### PR TITLE
Missing attributes and formatting for ATP outbound payloads

### DIFF
--- a/lib/aca_entities/atp/functions/build_outbound_relationship.rb
+++ b/lib/aca_entities/atp/functions/build_outbound_relationship.rb
@@ -75,7 +75,7 @@ module AcaEntities
               ::AcaEntities::MagiMedicaid::Mitc::Types::RelationshipCodeMap.invert[person_relationship[:relationship_code]] || '88'
             relation = RelationshipCodeMap[mitc_relationship_code]
             atp_relationship_code = AcaEntities::Types::RelationshipToTaxFilerCodeMap.invert[relation.to_s].to_s
-            collect << { :person => { :ref => "SBM#{person_relationship[:other_id]}" }, :family_relationship_code => atp_relationship_code,
+            collect << { :person => { :ref => "pe#{person_relationship[:other_id]}" }, :family_relationship_code => atp_relationship_code,
                          :caretaker_dependent_code => nil }
           end
         end

--- a/lib/aca_entities/atp/functions/medicaid_household_builder.rb
+++ b/lib/aca_entities/atp/functions/medicaid_household_builder.rb
@@ -17,7 +17,7 @@ module AcaEntities
             people = household[:people].map { |p| p[:person_id] }
             incomes = find_incomes(people, applicants_hash)&.flatten
             incomes.map! {|i| i.select {|k, _v| INCOME_FIELDS.include?(k)}}
-            member_references = people.map {|p| { ref: "SBM#{p}" }}
+            member_references = people.map {|p| { ref: "pe#{p}" }}
 
             collect << {
               household_incomes: incomes,

--- a/lib/aca_entities/atp/functions/tax_return_builder.rb
+++ b/lib/aca_entities/atp/functions/tax_return_builder.rb
@@ -21,18 +21,18 @@ module AcaEntities
             members = household[:tax_household_members].map {|m| m.dig(:applicant_reference, :person_hbx_id)}
 
             primary_tax_filer = find_primary_tax_filer(members, applicants_hash).first.to_s
-            primary_role_reference = { ref: "SBM#{primary_tax_filer}" }
+            primary_role_reference = { ref: "pe#{primary_tax_filer}" }
             primary_hash = { role_reference: primary_role_reference } if primary_tax_filer.present?
 
             spouse_tax_filer = find_spouse_tax_filer(members, person_relationships, member_id)
-            spouse_role_reference = { ref: "SBM#{spouse_tax_filer}" }
+            spouse_role_reference = { ref: "pe#{spouse_tax_filer}" }
             spouse_hash = { role_reference: spouse_role_reference } if spouse_tax_filer.present?
 
             dependents = find_dependents(members, applicants_hash).map(&:to_s)
-            dependents_hash = dependents.map {|id| { role_reference: { ref: "SBM#{id}" } } }
+            dependents_hash = dependents.map {|id| { role_reference: { ref: "pe#{id}" } } }
 
             household_size_quantity = members.count
-            household_member_references = members.map { |f| { ref: "SBM#{f}" } }
+            household_member_references = members.map { |f| { ref: "pe#{f}" } }
 
             income = household.dig(:annual_tax_household_income, :cents)
             income_dollars = cents_to_dollars(income) # convert to dollars

--- a/lib/aca_entities/atp/transformers/aces/applicant.rb
+++ b/lib/aca_entities/atp/transformers/aces/applicant.rb
@@ -11,7 +11,7 @@ module AcaEntities
         class Applicant < ::AcaEntities::Operations::Transforms::Transform
           include ::AcaEntities::Operations::Transforms::Transformer
 
-          map 'person_hbx_id', 'role_reference.ref', memoize: true, visible: true, function: ->(v) {"SBM#{v}"}
+          map 'person_hbx_id', 'role_reference.ref', memoize: true, visible: true, function: ->(v) {"pe#{v}"}
           add_key 'esi_eligible_indicator'
           map 'is_homeless', 'fixed_address_indicator'
           map 'attestation', 'attestation', memoize_record: true, visible: false
@@ -88,7 +88,7 @@ module AcaEntities
 
           map 'need_help_paying_bills', 'recent_medical_bills_indicator'
           add_key 'referral_activity.activity_id.identification_id', function: lambda {|v|
-            ["SBM", DateTime.now.strftime("%Y%m%d%H%M%S"), v.resolve('role_reference.ref').item].join
+            ["SBM", DateTime.now.strftime("%Y%m%d%H%M%S"), v.resolve('role_reference.ref').item&.slice(-3..-1)].join
           }
           add_key 'referral_activity.activity_date.date_time', value: ->(_v) {DateTime.now} # default value
           add_key 'referral_activity.sender_reference.ref', value: "Sender"

--- a/lib/aca_entities/atp/transformers/aces/family.rb
+++ b/lib/aca_entities/atp/transformers/aces/family.rb
@@ -49,7 +49,9 @@ module AcaEntities
               add_namespace 'transfer_header', 'aces.transfer_header', type: :hash do
                 add_namespace 'transfer_activity', 'aces.transfer_header.transfer_activity', type: :hash do
                   add_namespace 'transfer_id', 'aces.transfer_header.transfer_activity.transfer_id', type: :hash do
-                    add_key 'identification_id', function: ->(v) { "SBM#{v.resolve('hbx_id').item}#{DateTime.now.strftime('%Y%m%dT%H%M')}" }
+                    add_key 'identification_id', function: lambda { |v|
+                                                             "SBM#{v.resolve('hbx_id').item&.slice(-3..-1)}#{DateTime.now.strftime('%Y%m%dT%H%M')}"
+                                                           }
                     add_key 'identification_category_text'
                     add_key 'identification_jurisdiction'
                   end
@@ -123,7 +125,7 @@ module AcaEntities
 
               namespace 'family_members.*', nil, context: { name: 'members' } do
                 rewrap 'aces.people', type: :array do
-                  map 'hbx_id', 'id', function: ->(v) {"SBM#{v}"}
+                  map 'hbx_id', 'id', function: ->(v) {"pe#{v}"}
                   map 'is_primary_applicant', 'is_primary_applicant', memoize: true, visible: false, append_identifier: true
                   namespace 'person' do
 
@@ -238,7 +240,7 @@ module AcaEntities
               add_key 'physical_households', function: lambda { |v|
                 applicants_hash = v.resolve('family.magi_medicaid_applications.applicants').item
                 result = applicants_hash.keys.map(&:to_s).each_with_object([]) do |id, collect|
-                  collect << { :ref => "SBM#{id}" }
+                  collect << { :ref => "pe#{id}" }
                 end
                 [{ :household_member_references => result, :household_size_quantity => result.size }]
               }
@@ -246,7 +248,7 @@ module AcaEntities
               add_key 'insurance_application.ssf_primary_contact', function: lambda { |v|
                 ref = v.find(Regexp.new('is_primary_applicant.*')).select {|a|  a.item == true}.first.name.split('.').last
                 contact_preference = v.find(Regexp.new('consumer_role.contact_method.*')).select {|a|  a.name.split('.').last == ref}.first.item
-                { role_reference: { ref: "SBM#{ref}" }, contact_preference: ContactPreferenceCode[contact_preference] }
+                { role_reference: { ref: "pe#{ref}" }, contact_preference: ContactPreferenceCode[contact_preference] }
               }
 
               add_key 'insurance_application.ssf_signer', value: lambda { |v|

--- a/lib/aca_entities/atp/transformers/aces/family.rb
+++ b/lib/aca_entities/atp/transformers/aces/family.rb
@@ -49,7 +49,7 @@ module AcaEntities
               add_namespace 'transfer_header', 'aces.transfer_header', type: :hash do
                 add_namespace 'transfer_activity', 'aces.transfer_header.transfer_activity', type: :hash do
                   add_namespace 'transfer_id', 'aces.transfer_header.transfer_activity.transfer_id', type: :hash do
-                    add_key 'identification_id', function: ->(v) { "#{v.resolve('hbx_id').item}_#{DateTime.now.strftime('%Y%m%dT%H%M')}" }
+                    add_key 'identification_id', function: ->(v) { "SBM#{v.resolve('hbx_id').item}#{DateTime.now.strftime('%Y%m%dT%H%M')}" }
                     add_key 'identification_category_text'
                     add_key 'identification_jurisdiction'
                   end

--- a/lib/aca_entities/atp/transformers/aces/ssf_signer.rb
+++ b/lib/aca_entities/atp/transformers/aces/ssf_signer.rb
@@ -8,7 +8,7 @@ module AcaEntities
         class SsfSigner < ::AcaEntities::Operations::Transforms::Transform
           include ::AcaEntities::Operations::Transforms::Transformer
 
-          map 'ref', 'role_reference.ref', function: ->(v) {"SBM#{v}"}
+          map 'ref', 'role_reference.ref', function: ->(v) {"pe#{v}"}
           map 'first_name', 'signature.signature_name.given', memoize: true, visible: false
           map 'middle_name', 'signature.signature_name.middle', memoize: true, visible: false
           map 'last_name', 'signature.signature_name.sur', memoize: true, visible: false

--- a/lib/aca_entities/medicaid/atp/medicaid_household.rb
+++ b/lib/aca_entities/medicaid/atp/medicaid_household.rb
@@ -5,6 +5,7 @@ module AcaEntities
     module Atp
       # Entity for MedicaidHousehold
       class MedicaidHousehold < Dry::Struct
+        attribute :id, Types::String.optional.meta(omittable: true)
         attribute :household_incomes,       Types::Array.of(HouseholdIncome).optional.meta(omittable: true)
         # attribute :household_composition,  HouseholdComposition.optional.meta(omittable: true)
         attribute :effective_person_quantity, Types::Integer.optional.meta(omittable: true)

--- a/lib/aca_entities/medicaid/contracts/medicaid_household_contract.rb
+++ b/lib/aca_entities/medicaid/contracts/medicaid_household_contract.rb
@@ -7,6 +7,7 @@ module AcaEntities
       class MedicaidHouseholdContract < Dry::Validation::Contract
 
         params do
+          optional(:id).maybe(:string)
           optional(:household_incomes).maybe(:array)
           optional(:effective_person_quantity).maybe(:integer)
           optional(:income_above_highest_applicable_magi_standard_indicator).maybe(:bool)

--- a/lib/aca_entities/serializers/xml/medicaid/atp/medicaid_household.rb
+++ b/lib/aca_entities/serializers/xml/medicaid/atp/medicaid_household.rb
@@ -12,6 +12,8 @@ module AcaEntities
             tag 'MedicaidHousehold'
             namespace 'hix-ee'
 
+            attribute :id, String, namespace: "niem-s"
+
             # A monetary payment received by a household, usually on a regular basis.
             has_many :household_incomes, HouseholdIncome
 
@@ -28,7 +30,8 @@ module AcaEntities
 
             def self.domain_to_mapper(household)
               mapper = self.new
-              mapper.household_incomes = household.household_incomes.map { |hi| HouseholdIncome.domain_to_mapper(hi) }
+              mapper.id = household.id if household.id && !household.id.empty?
+              mapper.household_incomes = household.household_incomes&.map { |hi| HouseholdIncome.domain_to_mapper(hi) }
               mapper.income_above_highest_applicable_magi_standard_indicator = household.income_above_highest_applicable_magi_standard_indicator
               if household.effective_person_quantity && !household.effective_person_quantity.blank?
                 mapper.effective_person_quantity = household.effective_person_quantity
@@ -41,6 +44,7 @@ module AcaEntities
 
             def to_hash
               {
+                id: id,
                 household_incomes: household_incomes,
                 effective_person_quantity: effective_person_quantity,
                 income_above_highest_applicable_magi_standard_indicator: income_above_highest_applicable_magi_standard_indicator,

--- a/lib/aca_entities/serializers/xml/medicaid/atp/organization_primary_contact_information.rb
+++ b/lib/aca_entities/serializers/xml/medicaid/atp/organization_primary_contact_information.rb
@@ -24,7 +24,7 @@ module AcaEntities
             def self.domain_to_mapper(contact_info)
               mapper = self.new
               mapper.email_id = contact_info&.email_id
-              mapper.mailing_address = ContactMailingAddress.domain_to_mapper(contact_info&.mailing_address)
+              mapper.mailing_address = ContactMailingAddress.domain_to_mapper(contact_info&.mailing_address) if contact_info&.mailing_address
               mapper.telephone_number = ContactTelephoneNumber.domain_to_mapper(contact_info&.telephone_number) if contact_info&.telephone_number
               mapper
             end

--- a/spec/aca_entities/medicaid/atp/medicaid_household_spec.rb
+++ b/spec/aca_entities/medicaid/atp/medicaid_household_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ::AcaEntities::Medicaid::Atp::MedicaidHousehold,  dbclean: :aroun
 
     let(:optional_params) do
       {
+        id: "mh123",
         effective_person_quantity: 1,
         income_above_highest_applicable_magi_standard_indicator: true,
         household_member_references: [{ ref: "pe123" }],

--- a/spec/aca_entities/medicaid/contracts/medicaid_household_contract_spec.rb
+++ b/spec/aca_entities/medicaid/contracts/medicaid_household_contract_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ::AcaEntities::Medicaid::Contracts::MedicaidHouseholdContract, db
 
   let(:optional_params) do
     {
+      id: "mh123",
       effective_person_quantity: 1,
       income_above_highest_applicable_magi_standard_indicator: true,
       household_member_references: [{ ref: "pe123" }],

--- a/spec/aca_entities/serializers/xml/medicaid/atp/account_transfer_request_spec.rb
+++ b/spec/aca_entities/serializers/xml/medicaid/atp/account_transfer_request_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AcaEntities::Serializers::Xml::Medicaid::Atp::AccountTransferRequ
       receivers: [receiver],
 
       insurance_application: insurance_application,
-      medicaid_households: [],
+      medicaid_households: [medicaid_household],
       people: [person, dependent_person],
       tax_returns: [tax_return],
       physical_households: [{
@@ -408,6 +408,17 @@ RSpec.describe AcaEntities::Serializers::Xml::Medicaid::Atp::AccountTransferRequ
   let(:application_identity) do
     {
       identification_id: "A UUID"
+    }
+  end
+
+  let(:medicaid_household) do
+    {
+      id: "mh123",
+      effective_person_quantity: 1,
+      income_above_highest_applicable_magi_standard_indicator: true,
+      household_member_references: [{ ref: "pe123" }],
+      household_size_quantity: 1
+
     }
   end
 


### PR DESCRIPTION
[ME-180268623](https://www.pivotaltracker.com/n/projects/2502930/stories/180268623)

Resolved issues:
- change prefix to “pe" for role of person reference 
- add id attribute for medicaid household
- add "SBM" to beginning and remove underscore for  transferheader > IdentificationID 