### PR TITLE
Inbound ATP address fixes: Is Homeless, Verify Address Uniqueness

### DIFF
--- a/lib/aca_entities/atp/functions/address_builder.rb
+++ b/lib/aca_entities/atp/functions/address_builder.rb
@@ -10,15 +10,20 @@ module AcaEntities
           member_id = m_identifier || '*'
           contacts_information = @memoized_data.find(Regexp.new("record.people.#{member_id}.augementation")).map(&:item).last[:contacts]
 
-          contacts_information.each_with_object([]) do |contact_info, collector|
+          contacts_information.sort_by { |a| a[:category_code].downcase == "home" ? 0 : 1 }.each_with_object([]) do |contact_info, collector|
             next if contact_info[:category_code].downcase == 'residency'
             address = contact_info.dig(:contact, :mailing_address, :address)
 
-            collector << address_hash(address, contact_info) if address
+            address_hash = address_hash(address, contact_info) if address
+            collector << address_hash if address_hash && uniq_address(collector, address_hash)
           end
         end
 
         private
+
+        def uniq_address(collector, address)
+          collector.map { |ad| ad.except(:kind)}.exclude?(address.except(:kind))
+        end
 
         def address_hash(address, contact_info)
           zip = address[:location_postal_code][0..4] unless address[:location_postal_code].blank?  # only store 5-digit zip code

--- a/lib/aca_entities/atp/transformers/cv/family.rb
+++ b/lib/aca_entities/atp/transformers/cv/family.rb
@@ -8,7 +8,7 @@ require "aca_entities/functions/age_on"
 require 'aca_entities/atp/transformers/cv/phone'
 require 'dry/monads'
 require 'dry/monads/do'
-require 'pry'
+
 module AcaEntities
   module Atp
     module Transformers
@@ -112,7 +112,7 @@ module AcaEntities
                   }
                   map 'augementation', 'augementation', memoize_record: true, visible: false
                   add_key 'person.addresses', memoize_record: true, function: AcaEntities::Atp::Functions::AddressBuilder.new
-                  add_key 'is_homeless', function: lambda { |v|
+                  add_key 'person.is_homeless', function: lambda { |v|
                     member_id = v.find(/record.people.(\w+)$/).map(&:item).last
                     contacts_information = v.find(Regexp.new("record.people.#{member_id}.augementation")).map(&:item).last[:contacts]
                     contacts_information.select { |co| co[:category_code].downcase == "home" && co[:contact][:mailing_address].present? }.empty?

--- a/lib/aca_entities/atp/transformers/cv/family.rb
+++ b/lib/aca_entities/atp/transformers/cv/family.rb
@@ -8,7 +8,7 @@ require "aca_entities/functions/age_on"
 require 'aca_entities/atp/transformers/cv/phone'
 require 'dry/monads'
 require 'dry/monads/do'
-
+require 'pry'
 module AcaEntities
   module Atp
     module Transformers
@@ -57,12 +57,6 @@ module AcaEntities
                       add_key 'hbx_id', value: 1234
                       add_key 'person_health.is_tobacco_user', value: "unknown"
                       add_key 'person_health.is_physically_disabled', value: nil
-                      add_key 'is_homeless', function: lambda { |v|
-                        member_id = v.find(/record.people.(\w+)$/).map(&:item).last
-                        applicants = v.resolve(:'insurance_application.insurance_applicants').item
-                        return false unless applicants[member_id.to_sym]
-                        !applicants[member_id.to_sym][:fixed_address_indicator]
-                      }
                       add_key 'is_temporarily_out_of_state', function: lambda { |v|
                         member_id = v.find(/record.people.(\w+)$/).map(&:item).last
                         applicants = v.resolve(:'insurance_application.insurance_applicants').item
@@ -117,7 +111,12 @@ module AcaEntities
                     tribal_augmentation[:person_tribe_name]
                   }
                   map 'augementation', 'augementation', memoize_record: true, visible: false
-                  add_key 'person.addresses', function: AcaEntities::Atp::Functions::AddressBuilder.new
+                  add_key 'person.addresses', memoize_record: true, function: AcaEntities::Atp::Functions::AddressBuilder.new
+                  add_key 'is_homeless', function: lambda { |v|
+                    member_id = v.find(/record.people.(\w+)$/).map(&:item).last
+                    contacts_information = v.find(Regexp.new("record.people.#{member_id}.augementation")).map(&:item).last[:contacts]
+                    contacts_information.select { |co| co[:category_code].downcase == "home" && co[:contact][:mailing_address].present? }.empty?
+                  }
                   add_key 'person.emails', function: lambda {|v|
                     # revisit if condition for emails and phone for dependents
                     # if v.resolve('family.family_members.is_primary_applicant').item ==


### PR DESCRIPTION
ME-180530592

- Set the is homeless field to populate based on lack of home address
- Check for the same address being sent as both home and mailing and only transfer mailing if unique