### PR TITLE
applicant cannot be mitc state resident if temporarily out of state

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aca_entities (0.9.0)
+    aca_entities (0.10.0)
       deep_merge
       dry-monads (~> 1.2)
       dry-struct (~> 1.0)
@@ -76,14 +76,12 @@ GEM
     ice_nine (0.11.2)
     iso_country_codes (0.7.8)
     method_source (1.0.0)
-    mini_portile2 (2.6.1)
     minitest (5.14.4)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri-happymapper (0.8.1)
       nokogiri (~> 1.5)
-    oj (3.13.10)
+    oj (3.13.9)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aca_entities (0.10.0)
+    aca_entities (0.9.0)
       deep_merge
       dry-monads (~> 1.2)
       dry-struct (~> 1.0)
@@ -76,12 +76,14 @@ GEM
     ice_nine (0.11.2)
     iso_country_codes (0.7.8)
     method_source (1.0.0)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
-    nokogiri (1.12.5-x86_64-darwin)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     nokogiri-happymapper (0.8.1)
       nokogiri (~> 1.5)
-    oj (3.13.9)
+    oj (3.13.10)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)

--- a/lib/aca_entities/magi_medicaid/transformers/iap_to/mitc.rb
+++ b/lib/aca_entities/magi_medicaid/transformers/iap_to/mitc.rb
@@ -119,9 +119,10 @@ module AcaEntities
 
                   # logic to handle older applications that don't contatain the mitc_state_resident field
                   has_in_state_home_address = v.resolve('has_in_state_home_address').item
+                  is_temporarily_out_of_state = v.resolve('is_temporarily_out_of_state').item
                   is_homeless = v.resolve('is_homeless').item
-                  resides_in_state = has_in_state_home_address || is_homeless
-
+                  resides_in_state = (has_in_state_home_address && !is_temporarily_out_of_state) ||
+                                     (has_in_state_home_address && !is_temporarily_out_of_state && is_homeless)
                   boolean_string(resides_in_state)
                 }
                 add_key 'is_temporarily_out_of_state', function: ->(v) {

--- a/spec/aca_entities/magi_medicaid/transformers/iap_to/mitc_spec.rb
+++ b/spec/aca_entities/magi_medicaid/transformers/iap_to/mitc_spec.rb
@@ -169,6 +169,13 @@ RSpec.describe AcaEntities::MagiMedicaid::Transformers::IapTo::Mitc do
     end
 
     context 'mitc_state_resident' do
+      context 'when mitc_state_resident field is not present in payload' do
+        it 'should use non mitc_state_resident fields to determine if applicant resides in state' do
+          person = @transform_result[:people].first
+          expect(person[:resides_in_state_of_application]).to eq('Y')
+        end
+      end
+
       context 'when mitc_state_resident field is present in payload' do
         before do
           iap_application[:applicants].first.merge!(mitc_state_resident: false)


### PR DESCRIPTION
https://redmine.dchbx.org/issues/98135

- Logic for handling older applications that don't have the mitc_state_resident field is being updated to ensure the Mitc request payload is accurately constructed.  When building the Mitc request payload, an applicant cannot be considered a state resident if they are temporarily living out of state.