### PR TITLE
add geocode field to address entity and contract

### DIFF
--- a/lib/aca_entities/contracts/locations/address_contract.rb
+++ b/lib/aca_entities/contracts/locations/address_contract.rb
@@ -43,6 +43,7 @@ module AcaEntities
           optional(:start_on).maybe(:date)
           optional(:end_on).maybe(:date)
           optional(:lives_outside_state_temporarily).maybe(:bool)
+          optional(:geocode).maybe(:string)
         end
       end
     end

--- a/lib/aca_entities/locations/address.rb
+++ b/lib/aca_entities/locations/address.rb
@@ -31,6 +31,7 @@ module AcaEntities
       attribute :end_on, Types::Date.optional.meta(omittable: true)
 
       attribute :lives_outside_state_temporarily, Types::Bool.optional.meta(omittable: true)
+      attribute :geocode, Types::String.optional.meta(omittable: true)
     end
   end
 end

--- a/spec/aca_entities/contracts/locations/address_contract_spec.rb
+++ b/spec/aca_entities/contracts/locations/address_contract_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe ::AcaEntities::Contracts::Locations::AddressContract,  dbclean: :
         validation_status: 'ValidMatch',
         start_on: '2021/1/12',
         end_on: nil,
-        lives_outside_state_temporarily: false }
+        lives_outside_state_temporarily: false,
+        geocode: "00000" }
     end
     let(:error_message) { { :address_1 => ["is missing"] } }
 

--- a/spec/aca_entities/locations/address_spec.rb
+++ b/spec/aca_entities/locations/address_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe ::AcaEntities::Locations::Address, dbclean: :after_each do
         validation_status: nil,
         start_on: nil,
         end_on: nil,
-        lives_outside_state_temporarily: false
+        lives_outside_state_temporarily: false,
+        geocode: "00000"
       }
     end
 


### PR DESCRIPTION
ME-182215260

- adds optional geocode attribute to store a string representing a geocode value on the address entity
- updates address contract to account for new geocode field