### PR TITLE
ensure ssn is mapped to correct applicant on inbound transform

### DIFF
--- a/lib/aca_entities/atp/transformers/cv/family.rb
+++ b/lib/aca_entities/atp/transformers/cv/family.rb
@@ -74,7 +74,7 @@ module AcaEntities
                     end
                   end
 
-                  map 'ssn_identification', 'person.person_demographics.ssn_identification', memoize_record: true, append_identifier: true, visible: false
+                  map 'ssn_identification', 'person.ssn_identification', memoize_record: true, append_identifier: true, visible: false
                   map 'ssn_identification.identification_id', 'person.person_demographics.ssn', memoize: true, append_identifier: true, function:
                   lambda { |v|
                     return nil unless v
@@ -83,7 +83,7 @@ module AcaEntities
                   }
                   map 'sex', 'person.person_demographics.gender', memoize: true, append_identifier: true, function: ->(value) {value.downcase}
                   add_key 'person.person_demographics.no_ssn',
-                          function: ->(v) { v.resolve(:'person.person_demographics.ssn_identification', identifier: true).item.nil? }
+                          function: ->(v) { v.resolve(:'person.ssn_identification', identifier: true).item.nil? }
                   map 'birth_date.date', 'person.person_demographics.dob', memoize: true, append_identifier: true
                   add_key 'person.person_demographics.dob', memoize: true, append_identifier: true, function: lambda { |v|
                     member_id = v.find(/record.people.(\w+)$/).map(&:item).last

--- a/lib/aca_entities/atp/transformers/cv/family.rb
+++ b/lib/aca_entities/atp/transformers/cv/family.rb
@@ -74,6 +74,7 @@ module AcaEntities
                     end
                   end
 
+                  map 'ssn_identification', 'person.person_demographics.ssn_identification', memoize_record: true, append_identifier: true, visible: false
                   map 'ssn_identification.identification_id', 'person.person_demographics.ssn', memoize: true, append_identifier: true, function:
                   lambda { |v|
                     return nil unless v
@@ -82,7 +83,7 @@ module AcaEntities
                   }
                   map 'sex', 'person.person_demographics.gender', memoize: true, append_identifier: true, function: ->(value) {value.downcase}
                   add_key 'person.person_demographics.no_ssn',
-                          function: ->(v) { v.resolve(:'person_demographics.ssn', identifier: true).item.nil?}
+                          function: ->(v) { v.resolve(:'person.person_demographics.ssn_identification', identifier: true).item.nil? }
                   map 'birth_date.date', 'person.person_demographics.dob', memoize: true, append_identifier: true
                   add_key 'person.person_demographics.dob', memoize: true, append_identifier: true, function: lambda { |v|
                     member_id = v.find(/record.people.(\w+)$/).map(&:item).last


### PR DESCRIPTION
ME-181987485

- ATP inbound transformation was inaccurate when one applicant had SSN present but the following applicant did not.  This update guarantees that the no_ssn field for applicants with nil SSN values is mapped accurately.