### PR TITLE
initial commit for the devcontainer configuration files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+	"name": "Aca Entities Dev",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "mcr.microsoft.com/devcontainers/ruby:0-2.6.6-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/ruby:1": {"version":"2.6.6"},
+		"ghcr.io/devcontainers/features/java:1": {"version":"11", "distribution":"openjdk"},
+		"ghcr.io/devcontainers/features/node:1": {"version":"14"},
+		"ghcr.io/devcontainers/features/common-utils:2": {"installZsh":"true", "configureZshAsDefaultShell":"true","upgradePackages":"true"}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo apt update && sudo apt install -y libsodium23 && gem install bundler:2.2.28 && bundle install"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
 {
 	"name": "Aca Entities Dev",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	// "image": "mcr.microsoft.com/devcontainers/ruby:0-2.6.6-bullseye",
 	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
 	"features": {
 		"ghcr.io/devcontainers/features/ruby:1": {"version":"2.6.6"},


### PR DESCRIPTION
This adds the necessary files to use the "dev container" feature on VSCode, which is helpful especially for M1 macs. It has everything it needs to be able to run RSpec and rubocop