### PR TITLE
fix is_primary_indicator mapping for contact methods in atp xml

### DIFF
--- a/lib/aca_entities/atp/functions/contact_builder.rb
+++ b/lib/aca_entities/atp/functions/contact_builder.rb
@@ -9,6 +9,7 @@ module AcaEntities
   module Atp
     module Functions
       # build application and applicants
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
       class ContactBuilder
 
         def call(cache)
@@ -22,32 +23,42 @@ module AcaEntities
           @primary_applicant_id = @memoized_data.find(Regexp.new('is_primary_applicant.*')).select {|a|  a.item == true}.first.name.split('.').last
           @contact_method = @memoized_data.find(Regexp.new("consumer_role.contact_method.#{@primary_applicant_id}")).map(&:item).last
 
-          @primary_address_kind = addresses.any?{ |a| a[:kind] == "mailing"} ? "Mailing" : "Home"
-          @primary_phone_kind = phones.any?{ |a| a[:kind] == "mobile"} ? "Mobile" : phones.any?{ |a| a[:kind] == "home"} ? "Home" : "Work"
-          @primary_email_kind = emails.any?{ |a| a[:kind] == "home"} ? "Home" : "Work"
+          @primary_address_kind = addresses.any? { |a| a[:kind] == "mailing"} ? "Mailing" : "Home"
+          @primary_phone_kind = if phones.any? { |a| a[:kind] == "mobile"}
+                                  "Mobile"
+                                elsif phones.any? { |a| a[:kind] == "home"}
+                                  "Home"
+                                else
+                                  "Work"
+                                end
+          @primary_email_kind = emails.any? { |a| a[:kind] == "home"} ? "Home" : "Work"
 
           address_result = addresses.each_with_object([]) do |address, collector|
             result = ::AcaEntities::Atp::Transformers::Aces::Address.transform(address)
-            result[:is_primary_indicator] = AcaEntities::Atp::Types::ContactPreferenceCode[@contact_method] == "Mail" && result[:category_code] == @primary_address_kind
+            prefered_method = AcaEntities::Atp::Types::ContactPreferenceCode[@contact_method] == "Mail"
+            result[:is_primary_indicator] = prefered_method && result[:category_code] == @primary_address_kind
             collector << result
           end
 
           phone_result = phones.each_with_object([]) do |phone, collector|
-            next if AcaEntities::Atp::Types::ContactKinds[phone[:kind]].nil? #to rule out 'fax' and other types that arent valid contact methods
+            next if AcaEntities::Atp::Types::ContactKinds[phone[:kind]].nil? # to rule out 'fax' and other types that arent valid contact methods
             result = ::AcaEntities::Atp::Transformers::Aces::Phone.transform(phone)
-            result[:is_primary_indicator] = AcaEntities::Atp::Types::ContactPreferenceCode[@contact_method] == "TextMessage" && result[:category_code] == @primary_phone_kind
+            prefered_method = AcaEntities::Atp::Types::ContactPreferenceCode[@contact_method] == "TextMessage"
+            result[:is_primary_indicator] = prefered_method && result[:category_code] == @primary_phone_kind
             collector << result
           end
 
           email_result = emails.each_with_object([]) do |email, collector|
             result = ::AcaEntities::Atp::Transformers::Aces::Email.transform(email)
-            result[:is_primary_indicator] = AcaEntities::Atp::Types::ContactPreferenceCode[@contact_method] == "Email" && result[:category_code] == @primary_email_kind
+            prefered_method = AcaEntities::Atp::Types::ContactPreferenceCode[@contact_method] == "Email"
+            result[:is_primary_indicator] = prefered_method && result[:category_code] == @primary_email_kind
             collector << result
           end
 
           [address_result, phone_result, email_result].flatten
         end
       end
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
     end
   end
 end

--- a/lib/aca_entities/atp/functions/contact_builder.rb
+++ b/lib/aca_entities/atp/functions/contact_builder.rb
@@ -21,24 +21,28 @@ module AcaEntities
           phones = applicants_hash[member_id.to_sym][:phones]
           @primary_applicant_id = @memoized_data.find(Regexp.new('is_primary_applicant.*')).select {|a|  a.item == true}.first.name.split('.').last
           @contact_method = @memoized_data.find(Regexp.new("consumer_role.contact_method.#{@primary_applicant_id}")).map(&:item).last
+
           @primary_address_kind = addresses.any?{ |a| a[:kind] == "mailing"} ? "Mailing" : "Home"
+          @primary_phone_kind = phones.any?{ |a| a[:kind] == "mobile"} ? "Mobile" : phones.any?{ |a| a[:kind] == "home"} ? "Home" : "Work"
+          @primary_email_kind = emails.any?{ |a| a[:kind] == "home"} ? "Home" : "Work"
 
           address_result = addresses.each_with_object([]) do |address, collector|
             result = ::AcaEntities::Atp::Transformers::Aces::Address.transform(address)
             result[:is_primary_indicator] = AcaEntities::Atp::Types::ContactPreferenceCode[@contact_method] == "Mail" && result[:category_code] == @primary_address_kind
             collector << result
-            collector
           end
 
           phone_result = phones.each_with_object([]) do |phone, collector|
-            next if AcaEntities::Atp::Types::ContactKinds[phone[:kind]].nil?
-            collector << ::AcaEntities::Atp::Transformers::Aces::Phone.transform(phone)
-            collector
+            next if AcaEntities::Atp::Types::ContactKinds[phone[:kind]].nil? #to rule out 'fax' and other types that arent valid contact methods
+            result = ::AcaEntities::Atp::Transformers::Aces::Phone.transform(phone)
+            result[:is_primary_indicator] = AcaEntities::Atp::Types::ContactPreferenceCode[@contact_method] == "TextMessage" && result[:category_code] == @primary_phone_kind
+            collector << result
           end
 
           email_result = emails.each_with_object([]) do |email, collector|
-            collector << ::AcaEntities::Atp::Transformers::Aces::Email.transform(email)
-            collector
+            result = ::AcaEntities::Atp::Transformers::Aces::Email.transform(email)
+            result[:is_primary_indicator] = AcaEntities::Atp::Types::ContactPreferenceCode[@contact_method] == "Email" && result[:category_code] == @primary_email_kind
+            collector << result
           end
 
           [address_result, phone_result, email_result].flatten

--- a/lib/aca_entities/atp/transformers/aces/address.rb
+++ b/lib/aca_entities/atp/transformers/aces/address.rb
@@ -28,10 +28,7 @@ module AcaEntities
           map 'kind', 'category_code', memoize: true, visible: true, function: lambda { |v|
             v.capitalize
           }
-          add_key 'is_primary_indicator', value: lambda { |v|
-            kind = v.resolve('category_code').item
-            @contact_method == kind
-          }
+          add_key 'is_primary_indicator'
         end
       end
     end

--- a/lib/aca_entities/atp/transformers/aces/email.rb
+++ b/lib/aca_entities/atp/transformers/aces/email.rb
@@ -16,10 +16,7 @@ module AcaEntities
           map 'kind', 'category_code', memoize: true, visible: true, function: lambda { |v|
             v.capitalize
           }
-          add_key 'is_primary_indicator', value: lambda { |v|
-            kind = v.resolve('category_code').item
-            @contact_method == kind
-          }
+          add_key 'is_primary_indicator'
         end
       end
     end

--- a/lib/aca_entities/atp/transformers/aces/family.rb
+++ b/lib/aca_entities/atp/transformers/aces/family.rb
@@ -242,9 +242,9 @@ module AcaEntities
 
                     map 'consumer_role.language_preference', 'language_preference', memoize_record: true, visible: false
 
-                    map 'consumer_role.contact_method', 'consumer_role.contact_method', memoize_record: true, visible: false, append_identifier: true, function: lambda { |v|
+                    map 'consumer_role.contact_method', 'consumer_role.contact_method', function: lambda { |v|
                       AcaEntities::Atp::Types::ContactPreferenceCode[v]
-                    }
+                    }, memoize_record: true, visible: false, append_identifier: true
 
                     add_key 'person_augmentation.us_naturalized_citizen_indicator', function: lambda { |v|
                       member_id = v.find(/family.family_members.(\w+)$/).map(&:item).last

--- a/lib/aca_entities/atp/transformers/aces/family.rb
+++ b/lib/aca_entities/atp/transformers/aces/family.rb
@@ -24,16 +24,6 @@ module AcaEntities
         class Family < ::AcaEntities::Operations::Transforms::Transform
           include ::AcaEntities::Operations::Transforms::Transformer
 
-          ContactPreferenceCode = {
-            "Paper, Electronic and Text Message communications" => "Email",
-            "Electronic and Text Message communications" => "Email",
-            "Paper and Electronic communications" => "Email",
-            "Paper and Text Message communications" => "Mail",
-            "Only Text Message communication" => "TextMessage",
-            "Only Paper communication" => "Mail",
-            "Only Electronic communications" => "Email"
-          }.freeze
-
           namespace 'family' do
             rewrap 'aces', type: :hash do
               map 'family_flags', 'family_flags', memoize_record: true, visible: false
@@ -251,7 +241,11 @@ module AcaEntities
                     }
 
                     map 'consumer_role.language_preference', 'language_preference', memoize_record: true, visible: false
-                    map 'consumer_role.contact_method', 'consumer_role.contact_method', memoize_record: true, visible: false, append_identifier: true
+
+                    map 'consumer_role.contact_method', 'consumer_role.contact_method', memoize_record: true, visible: false, append_identifier: true, function: lambda { |v|
+                      AcaEntities::Atp::Types::ContactPreferenceCode[v]
+                    }
+
                     add_key 'person_augmentation.us_naturalized_citizen_indicator', function: lambda { |v|
                       member_id = v.find(/family.family_members.(\w+)$/).map(&:item).last
                       applicants_hash = v.resolve('family.magi_medicaid_applications.applicants').item
@@ -312,7 +306,7 @@ module AcaEntities
               add_key 'insurance_application.ssf_primary_contact', function: lambda { |v|
                 ref = v.find(Regexp.new('is_primary_applicant.*')).select {|a|  a.item == true}.first.name.split('.').last
                 contact_preference = v.find(Regexp.new('consumer_role.contact_method.*')).select {|a|  a.name.split('.').last == ref}.first.item
-                { role_reference: { ref: "pe#{ref}" }, contact_preference: ContactPreferenceCode[contact_preference] }
+                { role_reference: { ref: "pe#{ref}" }, contact_preference: AcaEntities::Atp::Types::ContactPreferenceCode[contact_preference] }
               }
 
               add_key 'insurance_application.ssf_signer', value: lambda { |v|

--- a/lib/aca_entities/atp/transformers/aces/phone.rb
+++ b/lib/aca_entities/atp/transformers/aces/phone.rb
@@ -18,10 +18,7 @@ module AcaEntities
           map 'kind', 'category_code', memoize: true, visible: true, function: lambda { |v|
             AcaEntities::Atp::Types::ContactKinds[v]
           }
-          add_key 'is_primary_indicator', value: lambda { |v|
-            kind = v.resolve('category_code').item
-            @contact_method == kind
-          }
+          add_key 'is_primary_indicator'
         end
       end
     end

--- a/lib/aca_entities/atp/types.rb
+++ b/lib/aca_entities/atp/types.rb
@@ -102,6 +102,16 @@ module AcaEntities
         #  - primary
         #  - branch
       }.freeze
+
+      ContactPreferenceCode = {
+        "Paper, Electronic and Text Message communications" => "Email",
+        "Electronic and Text Message communications" => "Email",
+        "Paper and Electronic communications" => "Email",
+        "Paper and Text Message communications" => "Mail",
+        "Only Text Message communication" => "TextMessage",
+        "Only Paper communication" => "Mail",
+        "Only Electronic communications" => "Email"
+      }.freeze
     end
   end
 end

--- a/lib/aca_entities/atp/types.rb
+++ b/lib/aca_entities/atp/types.rb
@@ -91,10 +91,10 @@ module AcaEntities
       }.freeze
 
       ContactKinds = {
-        'home' => 'Home', #mail, text, email
-        'work' => 'Work', #text, email
-        'mailing' => 'Mailing', #mail
-        'mobile' => 'Mobile' #text
+        'home' => 'Home', # mail, text, email
+        'work' => 'Work', # text, email
+        'mailing' => 'Mailing', # mail
+        'mobile' => 'Mobile' # text
 
         # Enroll kinds with no accepted mapping:
         #  - fax

--- a/lib/aca_entities/atp/types.rb
+++ b/lib/aca_entities/atp/types.rb
@@ -91,10 +91,11 @@ module AcaEntities
       }.freeze
 
       ContactKinds = {
-        'home' => 'Home',
-        'work' => 'Work',
-        'mailing' => 'Mailing',
-        'mobile' => 'Mobile'
+        'home' => 'Home', #mail, text, email
+        'work' => 'Work', #text, email
+        'mailing' => 'Mailing', #mail
+        'mobile' => 'Mobile' #text
+
         # Enroll kinds with no accepted mapping:
         #  - fax
         #  - phone

--- a/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
+++ b/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
         context "when there is a mailing and home address" do
           it "should mark the mailing address with the primary indicator" do
             doc = Nokogiri::XML.parse(result.value!)
-            #1nd & 2nd PersonContactInformationAssociation nodes are addresses
+            # 1nd & 2nd PersonContactInformationAssociation nodes are addresses
             contact_info = doc.xpath("//hix-core:PersonContactInformationAssociation", namespaces)[1]
             is_primary_indicator = contact_info.xpath("./nc:ContactInformationIsPrimaryIndicator", namespaces).text
             expect(is_primary_indicator).to eq "true"
@@ -236,12 +236,13 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
 
         context "when there is only a home address" do
           before do
-            payload_hash[:family][:magi_medicaid_applications][:applicants].first[:addresses] = [payload_hash[:family][:magi_medicaid_applications][:applicants].first[:addresses].first]
+            home_address = payload_hash[:family][:magi_medicaid_applications][:applicants].first[:addresses].first
+            payload_hash[:family][:magi_medicaid_applications][:applicants].first[:addresses] = [home_address]
           end
 
           it "should mark the home address with the primary indicator" do
             doc = Nokogiri::XML.parse(result.value!)
-            #1nd & 2nd PersonContactInformationAssociation nodes are addresses
+            # 1nd & 2nd PersonContactInformationAssociation nodes are addresses
             contact_info = doc.xpath("//hix-core:PersonContactInformationAssociation", namespaces)[0]
             is_primary_indicator = contact_info.xpath("./nc:ContactInformationIsPrimaryIndicator", namespaces).text
             expect(is_primary_indicator).to eq "true"
@@ -257,7 +258,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
         context "when there is multiple phone numbers" do
           it "should mark the phone number set as mobile with is_primary_indicator" do
             doc = Nokogiri::XML.parse(result.value!)
-            #2nd & 3rd PersonContactInformationAssociation nodes are phone #s
+            # 2nd & 3rd PersonContactInformationAssociation nodes are phone #s
             contact_info = doc.xpath("//hix-core:PersonContactInformationAssociation", namespaces)[3]
             is_primary_indicator = contact_info.xpath("./nc:ContactInformationIsPrimaryIndicator", namespaces).text
             expect(is_primary_indicator).to eq "true"
@@ -267,7 +268,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
         context "when there is only a home phone number" do
           it "should mark the home phone number with is_primary_indicator" do
             doc = Nokogiri::XML.parse(result.value!)
-            #2nd & 3rd PersonContactInformationAssociation nodes are phone #s
+            # 2nd & 3rd PersonContactInformationAssociation nodes are phone #s
             contact_info = doc.xpath("//hix-core:PersonContactInformationAssociation", namespaces)[3]
             is_primary_indicator = contact_info.xpath("./nc:ContactInformationIsPrimaryIndicator", namespaces).text
             expect(is_primary_indicator).to eq "true"
@@ -283,7 +284,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
         context "when there is multiple email addresses" do
           it "should mark the home email with is_primary_indicator" do
             doc = Nokogiri::XML.parse(result.value!)
-            #4th & 5th PersonContactInformationAssociation nodes are emails
+            # 4th & 5th PersonContactInformationAssociation nodes are emails
             contact_info = doc.xpath("//hix-core:PersonContactInformationAssociation", namespaces)[4]
             is_primary_indicator = contact_info.xpath("./nc:ContactInformationIsPrimaryIndicator", namespaces).text
             expect(is_primary_indicator).to eq "true"
@@ -292,11 +293,12 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
 
         context "when there is only a work email address" do
           before do
-            payload_hash[:family][:magi_medicaid_applications][:applicants].first[:emails] = [payload_hash[:family][:magi_medicaid_applications][:applicants].first[:emails].last]
+            work_email = payload_hash[:family][:magi_medicaid_applications][:applicants].first[:emails].last
+            payload_hash[:family][:magi_medicaid_applications][:applicants].first[:emails] = [work_email]
           end
           it "should mark the work email with is_primary_indicator" do
             doc = Nokogiri::XML.parse(result.value!)
-            #4th & 5th PersonContactInformationAssociation nodes are emails
+            # 4th & 5th PersonContactInformationAssociation nodes are emails
             contact_info = doc.xpath("//hix-core:PersonContactInformationAssociation", namespaces)[4]
             is_primary_indicator = contact_info.xpath("./nc:ContactInformationIsPrimaryIndicator", namespaces).text
             expect(is_primary_indicator).to eq "true"
@@ -427,8 +429,6 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
             end
           end
         end
-
-
       end
     end
   end

--- a/spec/support/atp/sample_payloads/simple_L_cv_payload.json
+++ b/spec/support/atp/sample_payloads/simple_L_cv_payload.json
@@ -397,7 +397,7 @@
         "broker_accounts": [],
         "documents": [],
         "payment_transactions": [],
-        "magi_medicaid_applications": 
+        "magi_medicaid_applications":
             {
                 "family_reference": {
                     "hbx_id": "10419"
@@ -460,8 +460,8 @@
                             "country_of_citizenship": "USA",
                             "expiration_date": "01-01-2020",
                             "issuing_country": "USA",
-                            "status": "nil", 
-                            "verification_type": "nil", 
+                            "status": "nil",
+                            "verification_type": "nil",
                             "comment": "nil"
                         },
                         "family_member_reference": {
@@ -561,17 +561,30 @@
                             {
                                 "kind": "home",
                                 "address": "M80@gmail.com"
+                            },
+                            {
+                                "kind": "work",
+                                "address": "E70@gmail.com"
                             }
                         ],
                         "phones": [
                             {
-                                "kind": "mobile",
+                                "kind": "home",
                                 "primary": false,
                                 "area_code": "301",
                                 "number": "1510342",
                                 "country_code": "",
                                 "extension": "",
                                 "full_phone_number": "3011510342"
+                            },
+                            {
+                                "kind": "mobile",
+                                "primary": true,
+                                "area_code": "301",
+                                "number": "6660000",
+                                "country_code": "",
+                                "extension": "",
+                                "full_phone_number": "3016660000"
                             }
                         ],
                         "incomes": [


### PR DESCRIPTION
IVL-184417119

It was discovered that `ContactInformationIsPrimaryIndicator`(`is_primary_indicator`) for `PersonContactInformationAssociation` in the generated XML for ATP was always being set to false and not properly mapped. This work corrects the mapping so that `is_primary_indicator` is set true for the highest priority selected contact method. 

For example: if the applicant has 2 addresses (home & mailing) and chooses paper communication, the `ContactInformationIsPrimaryIndicator` flag on the `PersonContactInformationAssociation` node for the mailing address will be set to true, and all other `PersonContactInformationAssociation` nodes(including phone#s and email) will be marked false for `ContactInformationIsPrimaryIndicator`.