### PR TITLE
 preserve members tag when only one member in CF XML payload

### DIFF
--- a/lib/aca_entities/pay_now/care_first.rb
+++ b/lib/aca_entities/pay_now/care_first.rb
@@ -26,6 +26,7 @@ require_relative 'care_first/operations/generate_xml'
 require 'aca_entities/serializers/xml/pay_now/care_first/member_name'
 require 'aca_entities/serializers/xml/pay_now/care_first/primary'
 require 'aca_entities/serializers/xml/pay_now/care_first/member'
+require 'aca_entities/serializers/xml/pay_now/care_first/members'
 require 'aca_entities/serializers/xml/pay_now/care_first/pay_now_transfer_payload'
 
 module AcaEntities

--- a/lib/aca_entities/pay_now/care_first/operations/generate_xml.rb
+++ b/lib/aca_entities/pay_now/care_first/operations/generate_xml.rb
@@ -19,7 +19,7 @@ module AcaEntities
             validated_transformed_payload = yield validate_transformed_payload(transformed_payload)
             entity = yield initialize_entity(validated_transformed_payload)
             serialized_payload = yield to_serialized_obj(entity)
-            xml_payload = serialized_payload.to_xml
+            xml_payload = yield to_xml(serialized_payload)
             Success(xml_payload)
           end
 
@@ -92,6 +92,16 @@ module AcaEntities
             end.to_result
 
             seralized_xml.success? ? seralized_xml : Failure("Serializers-PayNowTransferPayload -> #{seralized_xml.failure}")
+          end
+
+          def to_xml(serialized_payload)
+            xml_with_root_tag = serialized_payload.to_xml
+            doc = Nokogiri::XML(xml_with_root_tag)
+            root_node = doc.at_xpath('/PayNowTransferPayload')
+
+            Success(root_node.children.to_xml)
+          rescue StandardError => e
+            Failure("AcaEntities::PayNow::CareFirst::Operations::GenerateXml to_xml -> #{e}")
           end
         end
       end

--- a/lib/aca_entities/serializers/xml/pay_now/care_first.rb
+++ b/lib/aca_entities/serializers/xml/pay_now/care_first.rb
@@ -5,6 +5,7 @@ require "happymapper"
 require_relative "care_first/member_name"
 require_relative "care_first/primary"
 require_relative "care_first/member"
+require_relative "care_first/members"
 require_relative "care_first/pay_now_transfer_payload"
 
 module AcaEntities

--- a/lib/aca_entities/serializers/xml/pay_now/care_first/members.rb
+++ b/lib/aca_entities/serializers/xml/pay_now/care_first/members.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
 module AcaEntities
-    module Serializers
-      module Xml
-        module PayNow
-          module CareFirst
-            # Happymapper implementation for Member.
-            class Members
-              include HappyMapper
-  
-              tag 'members'
+  module Serializers
+    module Xml
+      module PayNow
+        module CareFirst
+          # Happymapper implementation for Member.
+          class Members
+            include HappyMapper
 
-              has_many :members, Member
-  
-              def self.domain_to_mapper(members)
-                mapper = self.new
-                mapper.members = members.map do |member|
-                    Member.domain_to_mapper(member)
-                end
-                mapper
+            tag 'members'
+
+            has_many :members, Member
+
+            def self.domain_to_mapper(members)
+              mapper = self.new
+              mapper.members = members.map do |member|
+                Member.domain_to_mapper(member)
               end
+              mapper
             end
           end
         end
       end
     end
   end
+end

--- a/lib/aca_entities/serializers/xml/pay_now/care_first/members.rb
+++ b/lib/aca_entities/serializers/xml/pay_now/care_first/members.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module AcaEntities
+    module Serializers
+      module Xml
+        module PayNow
+          module CareFirst
+            # Happymapper implementation for Member.
+            class Members
+              include HappyMapper
+  
+              tag 'members'
+
+              has_many :members, Member
+  
+              def self.domain_to_mapper(members)
+                mapper = self.new
+                mapper.members = members.map do |member|
+                    Member.domain_to_mapper(member)
+                end
+                mapper
+              end
+            end
+          end
+        end
+      end
+    end
+  end

--- a/lib/aca_entities/serializers/xml/pay_now/care_first/pay_now_transfer_payload.rb
+++ b/lib/aca_entities/serializers/xml/pay_now/care_first/pay_now_transfer_payload.rb
@@ -9,12 +9,7 @@ module AcaEntities
           class PayNowTransferPayload
             include HappyMapper
 
-            tag 'saml:AttributeValue'
-            register_namespace 'xmlns', 'http://openhbx.org/api/terms/1.0'
-            register_namespace 'cv', 'http://openhbx.org/api/terms/1.0'
-            register_namespace 'xsi', 'http://www.w3.org/2001/XMLSchema-instance'
-
-            attribute :type, String, tag: 'type', namespace: 'xsi'
+            tag 'PayNowTransferPayload'
 
             element :coverage_kind, String, tag: 'coverage_kind'
             has_one :primary, Primary
@@ -22,10 +17,9 @@ module AcaEntities
 
             def self.domain_to_mapper(pay_now_transfer_payload)
               mapper = self.new
-              mapper.type = 'cv:PaynowTransferPayloadType'
               mapper.coverage_kind = pay_now_transfer_payload.coverage_kind
               mapper.primary = Primary.domain_to_mapper(pay_now_transfer_payload.primary)
-              mapper.members = pay_now_transfer_payload.members.map {|m| Member.domain_to_mapper(m)}
+              mapper.members = Members.domain_to_mapper(pay_now_transfer_payload.members)
               mapper
             end
           end

--- a/spec/aca_entities/pay_now/care_first/operations/generate_xml_spec.rb
+++ b/spec/aca_entities/pay_now/care_first/operations/generate_xml_spec.rb
@@ -469,10 +469,22 @@ RSpec.describe AcaEntities::PayNow::CareFirst::Operations::GenerateXml do
       }
     end
 
-    it 'should generate xml' do
+    it 'should generate and unwrap the custom xml payload' do
       result = described_class.new.call(additional_info_payload)
       expect(result.success?).to be_truthy
-      expect(result.value!.split("\n").first).to eq '<?xml version="1.0"?>'
+      expect(result.value!.include?("<PayNowTransferPayload>")).to be_falsey
+      expect(result.value!.include?("<coverage_kind>")).to be_truthy
+      expect(result.value!.include?("<members>")).to be_truthy
+      expect(result.value!.include?("<primary>")).to be_truthy
+    end
+
+    context 'only one member on enrollment' do
+      let(:members) { [member] }
+
+      it 'should still contain the members tag in the output' do
+        result = described_class.new.call(additional_info_payload)
+        expect(result.value!.include?("<members>")).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
IVL-184640239

- Add members serializer to preserve members tag when only one member is present
- Unwrap root node in output xml to avoid duplicating tag in Enroll operation