### PR TITLE
safely handle nil encrypted ssn in CF Pay Now transform

### DIFF
--- a/lib/aca_entities/pay_now/care_first/transformers/coverage_and_members.rb
+++ b/lib/aca_entities/pay_now/care_first/transformers/coverage_and_members.rb
@@ -43,6 +43,7 @@ module AcaEntities
                       AcaEntities::PayNow::CareFirst::Types::SexofIndividualTerminologyTypeMap[gender]
                     }
                     map 'person_demographics.encrypted_ssn', 'ssn', function: lambda { |encrypted_ssn|
+                      return unless encrypted_ssn.present?
                       AcaEntities::Operations::Encryption::Decrypt.new.call({ value: encrypted_ssn }).value!
                     }
                     map 'relationship_to_primary', 'relationship', function: lambda {|relationship|

--- a/spec/aca_entities/pay_now/care_first/transformers/coverage_and_members_spec.rb
+++ b/spec/aca_entities/pay_now/care_first/transformers/coverage_and_members_spec.rb
@@ -500,7 +500,6 @@ RSpec.describe AcaEntities::PayNow::CareFirst::Transformers::CoverageAndMembers 
             ssn = AcaEntities::Operations::Encryption::Decrypt.new.call({ value: original_member[:person_demographics][:encrypted_ssn] }).value!
             sex = AcaEntities::PayNow::CareFirst::Types::SexofIndividualTerminologyTypeMap[original_member[:person_demographics][:gender]]
             relationship = AcaEntities::PayNow::CareFirst::Types::PaynowMemberRelationshipCodeMap[original_member[:relationship_to_primary]]
-            # expect(member).to have_key(:member)
             expect(transformed_member).to have_key(:exchange_assigned_member_id)
             expect(transformed_member[:exchange_assigned_member_id]).to eq original_member[:hbx_id]
             expect(transformed_member).to have_key(:birth_date)
@@ -541,6 +540,19 @@ RSpec.describe AcaEntities::PayNow::CareFirst::Transformers::CoverageAndMembers 
           expect(primary[:member_name]).to have_key(:person_name_prefix_text)
           expect(primary[:member_name]).to have_key(:person_name_suffix_text)
         end
+      end
+    end
+
+    context 'when ssn is nil' do
+      before do
+        additional_info_payload[:coverage_and_members][:members].first[:person_demographics][:encrypted_ssn] = nil
+      end
+
+      subject { described_class.transform(additional_info_payload) }
+
+      it 'should set ssn field to nil in output hash' do
+        output_ssn = subject[:pay_now_transfer_payload][:members].first[:member][:ssn]
+        expect(output_ssn).to eq nil
       end
     end
   end


### PR DESCRIPTION
IVL-184780268

**Additional context:** 
Residents enrolled through Coverall marketplace have nil value for encrypted_ssn field.  Transform is being updated to successfully handle enrollment members with no ssn provided.