### PR TITLE
skip validation of additional fields on enrolled esi benefits

### DIFF
--- a/lib/aca_entities/magi_medicaid/contracts/contract.rb
+++ b/lib/aca_entities/magi_medicaid/contracts/contract.rb
@@ -71,7 +71,7 @@ module AcaEntities
             value[:benefits].each_with_index do |benefit, b_index|
               failure_key = [:applicants, index, :benefits, b_index]
 
-              if benefit_kind_esi?(benefit[:kind])
+              if benefit_kind_esi?(benefit[:kind]) && !benefit_status_enrolled?(benefit[:status])
                 # employer
                 if check_if_blank?(benefit[:employer])
                   key(failure_key + [:employer]).failure(text: 'cannot be blank if benefit kind is employer_sponsored_insurance')

--- a/spec/aca_entities/magi_medicaid/contracts/application_contract_spec.rb
+++ b/spec/aca_entities/magi_medicaid/contracts/application_contract_spec.rb
@@ -551,7 +551,7 @@ RSpec.describe AcaEntities::MagiMedicaid::Contracts::ApplicationContract,  dbcle
           end
         end
 
-        context 'esi_covered' do
+        context 'esi_covered eligible' do
           let(:local_benefit) do
             benefit.delete(:esi_covered)
             benefit
@@ -560,6 +560,18 @@ RSpec.describe AcaEntities::MagiMedicaid::Contracts::ApplicationContract,  dbcle
           it 'should return failure with error message' do
             err = subject.call(input_params).errors.to_h[:applicants][0][:benefits][0][:esi_covered].first
             expect(err).to eq('is expected when benefit kind is employer_sponsored_insurance')
+          end
+        end
+
+        context 'esi_covered enrolled' do
+          let(:local_benefit) do
+            benefit.delete(:esi_covered)
+            benefit.merge({ status: 'is_enrolled' })
+          end
+
+          it 'should NOT return failure with error message' do
+            err = subject.call(input_params).errors.to_h.dig('applicants', 0, 'benefits', 0, 'esi_covered')
+            expect(err).to eq nil
           end
         end
 


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/n/projects/2640057/stories/185060660

Current behavior:  ESI benefits are validated for the presence of employer info for both eligible and enrolled statuses.

New behavior:  ESI benefits are validated for the presence of employer info only when status is set to eligible.