### PR TITLE
fix to accept member_determ key set as nil

### DIFF
--- a/lib/aca_entities/magi_medicaid/contracts/product_eligibility_determination_contract.rb
+++ b/lib/aca_entities/magi_medicaid/contracts/product_eligibility_determination_contract.rb
@@ -56,7 +56,10 @@ module AcaEntities
           optional(:medicaid_chip_category_threshold).maybe(Types::Money)
 
           optional(:category_determinations).array(CategoryDeterminationContract.params)
-          optional(:member_determinations).array(MemberDeterminationContract.params)
+
+          optional(:member_determinations).maybe(:array) do
+            nil? | each(MemberDeterminationContract.params)
+          end
         end
       end
     end

--- a/spec/aca_entities/magi_medicaid/operations/initialize_application_spec.rb
+++ b/spec/aca_entities/magi_medicaid/operations/initialize_application_spec.rb
@@ -22,17 +22,51 @@ RSpec.describe ::AcaEntities::MagiMedicaid::Operations::InitializeApplication do
   end
 
   context 'invalid params' do
-    before do
-      invalid_application = iap_application.merge({ applicants: [] })
-      @result = subject.call(invalid_application)
+    context 'empty applicant param' do
+      before do
+        invalid_application = iap_application.merge({ applicants: [] })
+        @result = subject.call(invalid_application)
+      end
+
+      it 'should return failure' do
+        expect(@result).to be_failure
+      end
+
+      it 'should return failure with error messages' do
+        expect(@result.failure.errors.to_h).to eq({ applicants: ['at least one applicant must be present'] })
+      end
+    end
+  end
+
+  context 'member_determinations param' do
+    context 'set to nil' do
+      before do
+        invalid_application = iap_application
+        ped = invalid_application[:tax_households].first[:tax_household_members].first[:product_eligibility_determination]
+        ped = ped.merge({ member_determinations: nil })
+        invalid_application[:tax_households].first[:tax_household_members].first[:product_eligibility_determination] = ped
+        @result = subject.call(invalid_application)
+      end
+
+      it 'should return success' do
+        expect(@result).to be_success
+      end
     end
 
-    it 'should return failure' do
-      expect(@result).to be_failure
-    end
+    context 'set to expected content' do
+      before do
+        invalid_application = iap_application
+        ped = invalid_application[:tax_households].first[:tax_household_members].first[:product_eligibility_determination]
+        ped = ped.merge({ member_determinations: [{ kind: 'Medicaid/CHIP Determination', is_eligible: true, determination_reasons: [:foo] }] })
+        invalid_application[:tax_households].first[:tax_household_members].first[:product_eligibility_determination] = ped
+        @result = subject.call(invalid_application)
+      end
 
-    it 'should return failure with error messages' do
-      expect(@result.failure.errors.to_h).to eq({ applicants: ['at least one applicant must be present'] })
+      it 'should return success' do
+        expect(@result).to be_success
+      end
     end
   end
 end
+
+


### PR DESCRIPTION
[TT6-185324149](https://www.pivotaltracker.com/story/show/185324149)

- fixed bug with product_eligibility_determination_contract to allow member_determination object to be set to nil
- added spec to check member_determination can be set with content AND nil