### PR TITLE
switch override rules from symbols to strings

### DIFF
--- a/lib/aca_entities/magi_medicaid/types.rb
+++ b/lib/aca_entities/magi_medicaid/types.rb
@@ -421,10 +421,10 @@ module AcaEntities
         'Total Ineligibility Determination'
       )
 
-      EligibilityOverrideRule = Types::Coercible::Symbol.enum(
-        :not_lawfully_present_pregnant,
-        :not_lawfully_present_chip_eligible,
-        :not_lawfully_present_under_twenty_one
+      EligibilityOverrideRule = Types::Coercible::String.enum(
+        'not_lawfully_present_pregnant',
+        'not_lawfully_present_chip_eligible',
+        'not_lawfully_present_under_twenty_one'
       )
     end
     # rubocop:enable Metrics/ModuleLength

--- a/spec/aca_entities/magi_medicaid/operations/initialize_application_spec.rb
+++ b/spec/aca_entities/magi_medicaid/operations/initialize_application_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::Operations::InitializeApplication do
            criteria_met: true,
            determination_reasons: [:foo],
            eligibility_overrides: [{
-             override_rule: :not_lawfully_present_pregnant,
+             override_rule: 'not_lawfully_present_pregnant',
              override_applied: true
            }] }]
       end


### PR DESCRIPTION
[TT6-185060667](https://www.pivotaltracker.com/story/show/185060667)

Note:
Sending params where override_rule is a string works when initializing the EligibilityOverride contract on its own, however, there is an issue when passing all application params to the InitializeApplication operation.  Apparently, Types::Coercible::Symbol does not work as expected in this case, i.e., when a string is deeply nested in the params hash.  

Validation of application params is failing when override_rule has a string value (despite being coercible to a symbol).  Switching override rules back to coercible String type results in successful validations.