### PR TITLE
use strings for determination reasons on member determination

### DIFF
--- a/lib/aca_entities/magi_medicaid/contracts/member_determination_contract.rb
+++ b/lib/aca_entities/magi_medicaid/contracts/member_determination_contract.rb
@@ -15,7 +15,7 @@ module AcaEntities
         params do
           required(:kind).maybe(::AcaEntities::MagiMedicaid::Types::MemberDeterminationKind)
           required(:criteria_met).maybe(:bool)
-          required(:determination_reasons).array(:symbol)
+          required(:determination_reasons).array(:string)
           required(:eligibility_overrides).array(AcaEntities::MagiMedicaid::Contracts::EligibilityOverrideContract.params)
         end
       end

--- a/lib/aca_entities/magi_medicaid/member_determination.rb
+++ b/lib/aca_entities/magi_medicaid/member_determination.rb
@@ -18,7 +18,8 @@ module AcaEntities
       # @!attribute [r] determination_reasons
       # The reasons the {Applicant} qualifies for the determination.
       # @return [Array]
-      attribute :determination_reasons, Types::Array.of(Types::Symbol)
+      # attribute :determination_reasons, Types::Array.of(Types::Coercible::String)
+      attribute :determination_reasons, Types::Array.of(Types::Coercible::String)
 
       # @!attribute [r] eligibility_overrides
       # The eligibility overrides for the determination.

--- a/lib/aca_entities/magi_medicaid/types.rb
+++ b/lib/aca_entities/magi_medicaid/types.rb
@@ -421,10 +421,10 @@ module AcaEntities
         'Total Ineligibility Determination'
       )
 
-      EligibilityOverrideRule = Types::Coercible::Symbol.enum(
-        :not_lawfully_present_pregnant,
-        :not_lawfully_present_chip_eligible,
-        :not_lawfully_present_under_twenty_one
+      EligibilityOverrideRule = Types::Coercible::String.enum(
+        'not_lawfully_present_pregnant',
+        'not_lawfully_present_chip_eligible',
+        'not_lawfully_present_under_twenty_one'
       )
     end
     # rubocop:enable Metrics/ModuleLength

--- a/spec/aca_entities/magi_medicaid/contracts/member_determination_contract_spec.rb
+++ b/spec/aca_entities/magi_medicaid/contracts/member_determination_contract_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::Contracts::MemberDeterminationContra
     {
       kind: 'Medicaid/CHIP Determination',
       criteria_met: true,
-      determination_reasons: [:mitc_override_not_lawfully_present_pregnant],
+      determination_reasons: ['mitc_override_not_lawfully_present_pregnant'],
       eligibility_overrides: [{
         override_rule: 'not_lawfully_present_pregnant',
         override_applied: true

--- a/spec/aca_entities/magi_medicaid/operations/initialize_application_spec.rb
+++ b/spec/aca_entities/magi_medicaid/operations/initialize_application_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::Operations::InitializeApplication do
            criteria_met: true,
            determination_reasons: [:foo],
            eligibility_overrides: [{
-             override_rule: :not_lawfully_present_pregnant,
+             override_rule: 'not_lawfully_present_pregnant',
              override_applied: true
            }] }]
       end

--- a/spec/aca_entities/magi_medicaid/operations/initialize_application_spec.rb
+++ b/spec/aca_entities/magi_medicaid/operations/initialize_application_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::Operations::InitializeApplication do
       let(:member_determinations) do
         [{ kind: 'Medicaid/CHIP Determination',
            criteria_met: true,
-           determination_reasons: [:foo],
+           determination_reasons: ['not_lawfully_present_pregnant'],
            eligibility_overrides: [{
              override_rule: 'not_lawfully_present_pregnant',
              override_applied: true

--- a/spec/aca_entities/magi_medicaid/product_eligibility_determination_spec.rb
+++ b/spec/aca_entities/magi_medicaid/product_eligibility_determination_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::ProductEligibilityDetermination, dbc
     let(:member_determinations) do
       [{ kind: 'Medicaid/CHIP Determination',
          criteria_met: true,
-         determination_reasons: [:mitc_override_not_lawfully_present_pregnant],
+         determination_reasons: ['mitc_override_not_lawfully_present_pregnant'],
          eligibility_overrides: eligibility_overrides }]
     end
 
@@ -120,7 +120,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::ProductEligibilityDetermination, dbc
     let(:member_determinations) do
       [{ kind: 'Insurance Assistance Determination',
          criteria_met: false,
-         determination_reasons: [:income_above_threshold],
+         determination_reasons: ['income_above_threshold'],
          eligibility_overrides: eligibility_overrides }]
     end
 
@@ -149,7 +149,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::ProductEligibilityDetermination, dbc
     let(:member_determinations) do
       [{ kind: 'Unassisted QHP Determination',
          criteria_met: true,
-         determination_reasons: [:income_above_threshold],
+         determination_reasons: ['income_above_threshold'],
          eligibility_overrides: eligibility_overrides }]
     end
 
@@ -177,7 +177,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::ProductEligibilityDetermination, dbc
     let(:member_determinations) do
       [{ kind: 'Total Ineligibility Determination',
          criteria_met: true,
-         determination_reasons: [:income_above_threshold],
+         determination_reasons: ['income_above_threshold'],
          eligibility_overrides: eligibility_overrides }]
     end
 


### PR DESCRIPTION
[TT6-185060667](https://www.pivotaltracker.com/story/show/185060667)

Note:
Switching the determination_reasons field to expect strings is related to the same issue tracked on this previous PR: https://github.com/ideacrew/aca_entities/pull/369