### PR TITLE
add relationship mapping for domestic_partner in paynow payload

### DIFF
--- a/lib/aca_entities/pay_now/care_first/types.rb
+++ b/lib/aca_entities/pay_now/care_first/types.rb
@@ -22,6 +22,7 @@ module AcaEntities
           'self' => '18',
           'spouse' => '01',
           'life_partner' => '53',
+          'domestic_partner' => '53',
           'ward' => '15',
           'child' => '19'
           # TODO: map other kinds of dependents to 19

--- a/spec/aca_entities/pay_now/care_first/operations/generate_xml_spec.rb
+++ b/spec/aca_entities/pay_now/care_first/operations/generate_xml_spec.rb
@@ -153,7 +153,8 @@ RSpec.describe AcaEntities::PayNow::CareFirst::Operations::GenerateXml do
         person_relationships: [{ :kind => "domestic_partner",
                                  :relative => { :hbx_id => "50001268", :first_name => "Spouse", :middle_name => nil, :last_name => "Test",
                                                 :encrypted_ssn => "EQbS0ycavkcS7BWbp0l+2YIEvP8EKMlIkg==\n",
-                                                :no_ssn => false, :dob => "1986-01-01", :gender => "male", :relationship_to_primary => "domestic_partner" } }],
+                                                :no_ssn => false, :dob => "1986-01-01", :gender => "male",
+                                                :relationship_to_primary => "domestic_partner" } }],
         consumer_role: {
           five_year_bar: false,
           requested_coverage_start_date: "2023-03-03",

--- a/spec/aca_entities/pay_now/care_first/operations/generate_xml_spec.rb
+++ b/spec/aca_entities/pay_now/care_first/operations/generate_xml_spec.rb
@@ -150,10 +150,10 @@ RSpec.describe AcaEntities::PayNow::CareFirst::Operations::GenerateXml do
         is_applying_for_assistance: false,
         is_active: true,
         is_disabled: nil,
-        person_relationships: [{ :kind => "spouse",
+        person_relationships: [{ :kind => "domestic_partner",
                                  :relative => { :hbx_id => "50001268", :first_name => "Spouse", :middle_name => nil, :last_name => "Test",
                                                 :encrypted_ssn => "EQbS0ycavkcS7BWbp0l+2YIEvP8EKMlIkg==\n",
-                                                :no_ssn => false, :dob => "1986-01-01", :gender => "male", :relationship_to_primary => "spouse" } }],
+                                                :no_ssn => false, :dob => "1986-01-01", :gender => "male", :relationship_to_primary => "domestic_partner" } }],
         consumer_role: {
           five_year_bar: false,
           requested_coverage_start_date: "2023-03-03",


### PR DESCRIPTION
[TT6-185183520](https://www.pivotaltracker.com/story/show/185183520)

- fix for bug with Carefirst's paynow functionality where families with a domestic_partner relationship were throwing an error upon attempting redirect to first payment page