### PR TITLE
change person id type to expected string

### DIFF
--- a/lib/aca_entities/magi_medicaid/mitc/applicant.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/applicant.rb
@@ -8,7 +8,7 @@ module AcaEntities
         # @!attribute [r] person_id
         # An integer representing the applicant.
         # @return [Integer]
-        attribute :person_id,        Types::Integer.meta(omittable: false)
+        attribute :person_id,        Types::String.meta(omittable: false)
 
         # @!attribute [r] medicaid_household
         # A hash representing the household composition and MAGI determination.

--- a/lib/aca_entities/magi_medicaid/mitc/contracts/applicant_contract.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/contracts/applicant_contract.rb
@@ -24,7 +24,7 @@ module AcaEntities
           # @option opts [Array] :qualified_children required
           # @return [Dry::Monads::Result]
           params do
-            required(:person_id).filled(:integer)
+            required(:person_id).filled(:string)
             required(:medicaid_household).hash(MedicaidHouseholdContract.params)
             required(:is_medicaid_eligible).filled(Types::YesNoKind)
             required(:is_chip_eligible).filled(Types::YesNoKind)

--- a/lib/aca_entities/magi_medicaid/mitc/contracts/person_contract.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/contracts/person_contract.rb
@@ -48,7 +48,7 @@ module AcaEntities
           # @option opts [Array] :relationships required
           # @return [Dry::Monads::Result]
           params do
-            required(:person_id).filled(:integer)
+            required(:person_id).filled(:string)
             required(:is_applicant).filled(Types::YesNoKind)
             required(:is_blind_or_disabled).filled(Types::YesNoKind)
             required(:is_full_time_student).filled(Types::YesNoKind)

--- a/lib/aca_entities/magi_medicaid/mitc/contracts/person_reference_contract.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/contracts/person_reference_contract.rb
@@ -11,7 +11,7 @@ module AcaEntities
           # @option opts [Integer] :person_id required
           # @return [Dry::Monads::Result]
           params do
-            required(:person_id).filled(:integer)
+            required(:person_id).filled(:string)
           end
         end
       end

--- a/lib/aca_entities/magi_medicaid/mitc/contracts/qualified_child_contract.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/contracts/qualified_child_contract.rb
@@ -14,7 +14,7 @@ module AcaEntities
           # @option opts [Hash] :relationship required
           # @return [Dry::Monads::Result]
           params do
-            required(:person_id).filled(:integer)
+            required(:person_id).filled(:string)
             required(:determination).hash(DeterminationContract.params)
             required(:deprived_child).hash(DeprivedChildContract.params)
             optional(:parent_caretaker_relationship).hash(ParentCaretakerRelationshipContract.params)

--- a/lib/aca_entities/magi_medicaid/mitc/contracts/relationship_contract.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/contracts/relationship_contract.rb
@@ -13,7 +13,7 @@ module AcaEntities
           # @option opts [String] :relationship_code required
           # @return [Dry::Monads::Result]
           params do
-            required(:other_id).filled(:integer)
+            required(:other_id).filled(:string)
             required(:attest_primary_responsibility).filled(Types::YesNoKind)
             required(:relationship_code).filled(Types::RelationshipCodeKind)
           end

--- a/lib/aca_entities/magi_medicaid/mitc/person.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/person.rb
@@ -8,7 +8,7 @@ module AcaEntities
         # @!attribute [r] person_id
         # An integer representing the applicant, only for the use of the submitter
         # @return [Integer]
-        attribute :person_id,        Types::Integer.meta(omittable: false)
+        attribute :person_id,        Types::String.meta(omittable: false)
 
         # @!attribute [r] is_applicant
         # A boolean if the person applying for insurance.

--- a/lib/aca_entities/magi_medicaid/mitc/person_reference.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/person_reference.rb
@@ -5,7 +5,7 @@ module AcaEntities
     module Mitc
       class PersonReference < Dry::Struct
 
-        attribute :person_id,  Types::Integer.meta(omitttable: false)
+        attribute :person_id,  Types::String.meta(omitttable: false)
 
       end
     end

--- a/lib/aca_entities/magi_medicaid/mitc/qualified_child.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/qualified_child.rb
@@ -9,7 +9,7 @@ module AcaEntities
         # @!attribute [r] person_id
         # An integer representing the applicant.
         # @return [Integer]
-        attribute :person_id,      Types::Integer.meta(omittable: false)
+        attribute :person_id,      Types::String.meta(omittable: false)
 
         # @!attribute [r] determination
         # Determinations: a hash containing only:

--- a/lib/aca_entities/magi_medicaid/mitc/relationship.rb
+++ b/lib/aca_entities/magi_medicaid/mitc/relationship.rb
@@ -6,7 +6,7 @@ module AcaEntities
       class Relationship < Dry::Struct
 
         # the person ID of the other person
-        attribute :other_id,  Types::Integer.meta(omittable: false)
+        attribute :other_id,  Types::String.meta(omittable: false)
         attribute :attest_primary_responsibility, Types::YesNoKind.meta(omittable: false)
         attribute :relationship_code, Types::RelationshipCodeKind.meta(omittable: false)
 


### PR DESCRIPTION
@mdkaraman and I found that the expected `person_id` type in aca_entities is of type Integer while the underlying type is a String. In production this is not an issue since the string is coerced but in development a UUID is generated that includes alphanumeric characters preventing the coercion. This PR is primarily to open the conversation with @saikumar9 around this issue. If it is indeed correct we can move forward.