### PR TITLE
fix submission terms name

### DIFF
--- a/lib/aca_entities/atp/functions/build_application.rb
+++ b/lib/aca_entities/atp/functions/build_application.rb
@@ -46,7 +46,7 @@ module AcaEntities
             is_renewal_authorized: @memoized_data.resolve('is_renewal_authorized').item,
             family_reference: { hbx_id: @memoized_data.resolve('family.hbx_id').item.to_s },
             aptc_effective_date: Date.today, # default value
-            application_submission_terms: ssf_attestation_hash[:non_perjury_indicator],
+            submission_terms: ssf_attestation_hash[:non_perjury_indicator],
             medicaid_insurance_collection_terms: ssf_attestation_hash[:medicaid_obligations_indicator],
             report_change_terms: ssf_attestation_hash[:report_change_terms],
             years_to_renew: @memoized_data.resolve('insurance_application.coverage_renewal_year_quantity')&.item,

--- a/spec/aca_entities/atp/functions/build_application_spec.rb
+++ b/spec/aca_entities/atp/functions/build_application_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
 
     context "with valid xml containing non perjury indicator" do
       it "should map the non perjury indicator to application_submission_terms on the application" do
-        expect(@result[:application_submission_terms]).to eq @ssf_attestation[:non_perjury_indicator]
+        expect(@result[:submission_terms]).to eq @ssf_attestation[:non_perjury_indicator]
       end
     end
 


### PR DESCRIPTION
Rename `application_submission_terms` to the correct `submission_terms`

https://www.pivotaltracker.com/story/show/185610738