### PR TITLE
atp attestation mapping fixes

### DIFF
--- a/lib/aca_entities/atp/functions/build_application.rb
+++ b/lib/aca_entities/atp/functions/build_application.rb
@@ -51,7 +51,8 @@ module AcaEntities
             report_change_terms: ssf_attestation_hash[:report_change_terms],
             years_to_renew: @memoized_data.resolve('coverage_renewal_year_quantity')&.item,
             medicaid_terms: medicaid_terms_value,
-            parent_living_out_of_home_terms: parent_living_out_of_home_terms_value
+            parent_living_out_of_home_terms: parent_living_out_of_home_terms_value,
+            attestation_terms: ssf_attestation_hash[:attestation_terms]
           }
         end
 
@@ -62,7 +63,8 @@ module AcaEntities
               {
                 non_perjury_indicator: attestation[:non_perjury_indicator],
                 medicaid_obligations_indicator: attestation[:medicaid_obligations_indicator],
-                report_change_terms: attestation[:information_changes_indicator]
+                report_change_terms: attestation[:information_changes_indicator],
+                attestation_terms: attestation[:collections_agreement_indicator]
               }
             else
               {}

--- a/lib/aca_entities/atp/functions/build_application.rb
+++ b/lib/aca_entities/atp/functions/build_application.rb
@@ -49,7 +49,7 @@ module AcaEntities
             application_submission_terms: ssf_attestation_hash[:non_perjury_indicator],
             medicaid_insurance_collection_terms: ssf_attestation_hash[:medicaid_obligations_indicator],
             report_change_terms: ssf_attestation_hash[:report_change_terms],
-            years_to_renew: @memoized_data.resolve('insurance_application.coverage_renewal_year_quantity')&.item,
+            years_to_renew: @memoized_data.resolve('coverage_renewal_year_quantity')&.item,
             medicaid_terms: medicaid_terms_value,
             parent_living_out_of_home_terms: parent_living_out_of_home_terms_value
           }
@@ -71,7 +71,7 @@ module AcaEntities
         end
 
         def medicaid_terms_value
-          renewal_year_quantity = @memoized_data.resolve('insurance_application.coverage_renewal_year_quantity')&.item
+          renewal_year_quantity = @memoized_data.resolve('coverage_renewal_year_quantity')&.item
           renewal_year_quantity&.positive?
         end
 

--- a/spec/aca_entities/atp/functions/build_application_spec.rb
+++ b/spec/aca_entities/atp/functions/build_application_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
         expect(@result[:report_change_terms]).to eq @ssf_attestation[:information_changes_indicator]
       end
     end
-    
+
     context "with valid attestation terms" do
       it "should map the attestation terms to attestation_terms on the application" do
         expect(@result[:attestation_terms]).to eq @ssf_attestation[:attestation_terms]

--- a/spec/aca_entities/atp/functions/build_application_spec.rb
+++ b/spec/aca_entities/atp/functions/build_application_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
       expect(result[:applicants][1][:has_eligible_health_coverage]).to be nil
     end
   end
-  
+
   context "with valid xml containing applicant with naturalized citizen status" do
     before do
       @result = subject.first
@@ -47,7 +47,7 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
       expect(@result[:applicants][2][:citizenship_immigration_status_information][:citizen_status]).to eq("not_lawfully_present_in_us")
     end
   end
-  
+
   context "with valid xml containing pregnant and post partum applicant" do
     before do
       @result = subject.first
@@ -77,7 +77,7 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
       expect(@result[:applicants][0][:pregnancy_information][:pregnancy_due_on]).to be nil
     end
   end
-  
+
   context "with valid xml containing naturalization certificate document information" do
     before do
       @result = subject.first
@@ -93,25 +93,25 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
       expect(@result[:applicants][1][:alien_number]).to be nil
     end
   end
-  
+
   context "ssf attestation" do
     before do
       @ssf_attestation = context.resolve("insurance_application.ssf_signer.ssf_attestation").item
       @result = subject.first
     end
-    
+
     context "with valid xml containing non perjury indicator" do
       it "should map the non perjury indicator to application_submission_terms on the application" do
         expect(@result[:submission_terms]).to eq @ssf_attestation[:non_perjury_indicator]
       end
     end
-    
+
     context "with valid xml containing medicaid obligations indicator" do
       it "should map the medicaid obligations indicator to medicaid_insurance_collection_terms on the application" do
         expect(@result[:medicaid_insurance_collection_terms]).to eq @ssf_attestation[:medicaid_obligations_indicator]
       end
     end
-    
+
     context "with valid xml containing medicaid obligations indicator" do
       it "should map the information_changes_indicator indicator to report_change_terms on the application" do
         expect(@result[:report_change_terms]).to eq @ssf_attestation[:information_changes_indicator]
@@ -123,47 +123,47 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
         expect(@result[:attestation_terms]).to eq @ssf_attestation[:attestation_terms]
       end
     end
-  
+
   end
-  
+
   context "insurance application coverage renewal year quantity" do
     before do
       @coverage_year_quantity = context.resolve("coverage_renewal_year_quantity").item
       @result = subject.first
     end
-    
+
     context "with valid xml containing coverage renewal year quantity" do
       it "should map the coverage_renewal_year_quantity to years_to_renew on the application" do
         expect(@result[:years_to_renew]).to eq @coverage_year_quantity
       end
-      
+
       it "should set the medicaid_terms to true on the application when renewal year quantity is greater than 0" do
         expect(@result[:medicaid_terms]).to eq true
       end
     end
   end
-  
+
   context "with valid xml containing applicant with absent parent or spouse code as Yes" do
     before do
       @result = subject.first
     end
-    
+
     it "should return parent_living_out_of_home_terms on the application as true" do
       expect(@result[:parent_living_out_of_home_terms]).to eq true
     end
   end
-  
+
   context "with valid xml containing applicant with an alimony and ira deduction" do
     before do
       @result = subject.first
     end
-    
+
     it "should return correct alimony deduction type, frequency, and amount" do
       expect(@result[:applicants][0][:deductions].first[:kind]).to eq("alimony_paid")
       expect(@result[:applicants][0][:deductions].first[:frequency_kind]).to eq("monthly")
       expect(@result[:applicants][0][:deductions].first[:amount]).to eq(500)
     end
-    
+
     it "should return correct ira deduction type, frequency, and amount" do
       expect(@result[:applicants][0][:deductions].last[:kind]).to eq("ira_deduction")
       expect(@result[:applicants][0][:deductions].last[:frequency_kind]).to eq("yearly")

--- a/spec/aca_entities/atp/functions/build_application_spec.rb
+++ b/spec/aca_entities/atp/functions/build_application_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
       expect(result[:applicants][1][:has_eligible_health_coverage]).to be nil
     end
   end
-
+  
   context "with valid xml containing applicant with naturalized citizen status" do
     before do
       @result = subject.first
@@ -47,7 +47,7 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
       expect(@result[:applicants][2][:citizenship_immigration_status_information][:citizen_status]).to eq("not_lawfully_present_in_us")
     end
   end
-
+  
   context "with valid xml containing pregnant and post partum applicant" do
     before do
       @result = subject.first
@@ -77,7 +77,7 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
       expect(@result[:applicants][0][:pregnancy_information][:pregnancy_due_on]).to be nil
     end
   end
-
+  
   context "with valid xml containing naturalization certificate document information" do
     before do
       @result = subject.first
@@ -93,71 +93,77 @@ RSpec.describe AcaEntities::Atp::Functions::BuildApplication do
       expect(@result[:applicants][1][:alien_number]).to be nil
     end
   end
-
+  
   context "ssf attestation" do
     before do
       @ssf_attestation = context.resolve("insurance_application.ssf_signer.ssf_attestation").item
       @result = subject.first
     end
-
+    
     context "with valid xml containing non perjury indicator" do
       it "should map the non perjury indicator to application_submission_terms on the application" do
         expect(@result[:submission_terms]).to eq @ssf_attestation[:non_perjury_indicator]
       end
     end
-
+    
     context "with valid xml containing medicaid obligations indicator" do
       it "should map the medicaid obligations indicator to medicaid_insurance_collection_terms on the application" do
         expect(@result[:medicaid_insurance_collection_terms]).to eq @ssf_attestation[:medicaid_obligations_indicator]
       end
     end
-
+    
     context "with valid xml containing medicaid obligations indicator" do
       it "should map the information_changes_indicator indicator to report_change_terms on the application" do
         expect(@result[:report_change_terms]).to eq @ssf_attestation[:information_changes_indicator]
       end
     end
-
+    
+    context "with valid attestation terms" do
+      it "should map the attestation terms to attestation_terms on the application" do
+        expect(@result[:attestation_terms]).to eq @ssf_attestation[:attestation_terms]
+      end
+    end
+  
   end
-
+  
   context "insurance application coverage renewal year quantity" do
     before do
-      @coverage_year_quantity = context.resolve("insurance_application.coverage_renewal_year_quantity").item
+      @coverage_year_quantity = context.resolve("coverage_renewal_year_quantity").item
       @result = subject.first
     end
-
+    
     context "with valid xml containing coverage renewal year quantity" do
       it "should map the coverage_renewal_year_quantity to years_to_renew on the application" do
         expect(@result[:years_to_renew]).to eq @coverage_year_quantity
       end
-
+      
       it "should set the medicaid_terms to true on the application when renewal year quantity is greater than 0" do
         expect(@result[:medicaid_terms]).to eq true
       end
     end
   end
-
+  
   context "with valid xml containing applicant with absent parent or spouse code as Yes" do
     before do
       @result = subject.first
     end
-
+    
     it "should return parent_living_out_of_home_terms on the application as true" do
       expect(@result[:parent_living_out_of_home_terms]).to eq true
     end
   end
-
+  
   context "with valid xml containing applicant with an alimony and ira deduction" do
     before do
       @result = subject.first
     end
-
+    
     it "should return correct alimony deduction type, frequency, and amount" do
       expect(@result[:applicants][0][:deductions].first[:kind]).to eq("alimony_paid")
       expect(@result[:applicants][0][:deductions].first[:frequency_kind]).to eq("monthly")
       expect(@result[:applicants][0][:deductions].first[:amount]).to eq(500)
     end
-
+    
     it "should return correct ira deduction type, frequency, and amount" do
       expect(@result[:applicants][0][:deductions].last[:kind]).to eq("ira_deduction")
       expect(@result[:applicants][0][:deductions].last[:frequency_kind]).to eq("yearly")

--- a/spec/support/atp/inbound_build_application.rb
+++ b/spec/support/atp/inbound_build_application.rb
@@ -460,7 +460,7 @@ RSpec.shared_context "inbound_build_application" do
                                                                :person_identification => nil } }
     }
   end
-  
+
   let(:context) do
     # rubocop:enable Layout/LineLength
     AcaEntities::Operations::Transforms::Context.new(context_hash)

--- a/spec/support/atp/inbound_build_application.rb
+++ b/spec/support/atp/inbound_build_application.rb
@@ -7,7 +7,7 @@ RSpec.shared_context "inbound_build_application" do
     {
       "external_id" => { :name => "external_id",
                          :item => "IDC1000886" },
-      "insurance_application.coverage_renewal_year_quantity" => { :name => "insurance_application.coverage_renewal_year_quantity", :item => 1 },
+      "insurance_application.coverage_renewal_year_quantity" => { :name => "coverage_renewal_year_quantity", :item => 1 },
       "insurance_application.insurance_applicants" => { :name => "insurance_application.insurance_applicants",
                                                         :item => { :IDC1003158 => { :id => "IDC1003158",
                                                                                     :role_reference => { :ref => "IDC1003158" },
@@ -165,7 +165,8 @@ RSpec.shared_context "inbound_build_application" do
                                                                          :privacy_agreement_indicator => true,
                                                                          :pending_charges_indicator => true,
                                                                          :information_changes_indicator => true,
-                                                                         :application_terms_indicator => true } },
+                                                                         :application_terms_indicator => true,
+                                                                         :attestation_terms => true } },
       "tax_returns" => { :name => "tax_returns",
                          :item => nil },
       "record.people.IDC1003158" => { :name => "record.people.IDC1003158",
@@ -459,7 +460,7 @@ RSpec.shared_context "inbound_build_application" do
                                                                :person_identification => nil } }
     }
   end
-
+  
   let(:context) do
     # rubocop:enable Layout/LineLength
     AcaEntities::Operations::Transforms::Context.new(context_hash)


### PR DESCRIPTION
- Add `attestation_terms` as a mapped field which was discovered to be necessary when `parent_living_out_of_home_terms` is true
- Properly resolve `years_to_renew`.

[TT6-185610738](https://www.pivotaltracker.com/story/show/185610738)