### PR TITLE
removes expiration_date requirement for I766 vlp doc

### DIFF
--- a/lib/aca_entities/fdsh/vlp/h92/contracts/vlp_v37_contract.rb
+++ b/lib/aca_entities/fdsh/vlp/h92/contracts/vlp_v37_contract.rb
@@ -32,8 +32,7 @@ module AcaEntities
           CARD_NUMBER_REQUIRED_SUBJECTS = ['I-551 (Permanent Resident Card)',
                                            'I-766 (Employment Authorization Card)'].freeze
 
-          EXPIRATION_DATE_REQUIRED_SUBJECTS = ['I-766 (Employment Authorization Card)',
-                                               'I-94 (Arrival/Departure Record) in Unexpired Foreign Passport',
+          EXPIRATION_DATE_REQUIRED_SUBJECTS = ['I-94 (Arrival/Departure Record) in Unexpired Foreign Passport',
                                                'Unexpired Foreign Passport'].freeze
 
           DESCRIPTION_REQUIRED_SUBJECTS = ['Other (With Alien Number)',

--- a/spec/aca_entities/fdsh/vlp/h92/contracts/vlp_v37_contract_spec.rb
+++ b/spec/aca_entities/fdsh/vlp/h92/contracts/vlp_v37_contract_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe AcaEntities::Fdsh::Vlp::H92::VlpV37Contract, type: :model, dbclea
 
   context "I-766 (Employment Authorization Card)" do
     let(:valid_params) do
-      { subject: 'I-766 (Employment Authorization Card)', alien_number: '123456789', card_number: '1234567890123', expiration_date: Date.today.to_s }
+      { subject: 'I-766 (Employment Authorization Card)', alien_number: '123456789', card_number: '1234567890123' }
     end
 
     context 'for success case' do


### PR DESCRIPTION
[IVL Product Development - 186143280](https://www.pivotaltracker.com/story/show/186143280)

Relaxes validation for expiration_date which is not required for I766 VLP Document type.