### PR TITLE
adds country_of_citizenship validation for some vlp docs

### DIFF
--- a/lib/aca_entities/fdsh/vlp/h92/contracts/vlp_v37_contract.rb
+++ b/lib/aca_entities/fdsh/vlp/h92/contracts/vlp_v37_contract.rb
@@ -32,6 +32,12 @@ module AcaEntities
           CARD_NUMBER_REQUIRED_SUBJECTS = ['I-551 (Permanent Resident Card)',
                                            'I-766 (Employment Authorization Card)'].freeze
 
+          COUNTRY_OF_CITIZENSHIP_REQUIRED_SUBJECTS = [
+            'I-94 (Arrival/Departure Record) in Unexpired Foreign Passport',
+            'Machine Readable Immigrant Visa (with Temporary I-551 Language)',
+            'Unexpired Foreign Passport'
+          ].freeze
+
           EXPIRATION_DATE_REQUIRED_SUBJECTS = ['I-94 (Arrival/Departure Record) in Unexpired Foreign Passport',
                                                'Unexpired Foreign Passport'].freeze
 
@@ -87,6 +93,10 @@ module AcaEntities
 
           rule(:card_number) do
             key.failure(message(values[:subject])) if  CARD_NUMBER_REQUIRED_SUBJECTS.include?(values[:subject]) && value.blank?
+          end
+
+          rule(:country_of_citizenship) do
+            key.failure(message(values[:subject])) if  COUNTRY_OF_CITIZENSHIP_REQUIRED_SUBJECTS.include?(values[:subject]) && value.blank?
           end
 
           rule(:expiration_date) do

--- a/spec/aca_entities/fdsh/vlp/h92/contracts/vlp_v37_contract_spec.rb
+++ b/spec/aca_entities/fdsh/vlp/h92/contracts/vlp_v37_contract_spec.rb
@@ -388,7 +388,12 @@ RSpec.describe AcaEntities::Fdsh::Vlp::H92::VlpV37Contract, type: :model, dbclea
 
   context "Machine Readable Immigrant Visa (with Temporary I-551 Language)" do
     let(:valid_params) do
-      { subject: 'Machine Readable Immigrant Visa (with Temporary I-551 Language)', passport_number: '123456789', alien_number: '123456789' }
+      {
+        subject: 'Machine Readable Immigrant Visa (with Temporary I-551 Language)',
+        passport_number: '123456789',
+        alien_number: '123456789',
+        country_of_citizenship: 'United States'
+      }
     end
 
     context 'for success case' do
@@ -550,8 +555,13 @@ RSpec.describe AcaEntities::Fdsh::Vlp::H92::VlpV37Contract, type: :model, dbclea
 
   context "I-94 (Arrival/Departure Record) in Unexpired Foreign Passport" do
     let(:valid_params) do
-      { subject: 'I-94 (Arrival/Departure Record) in Unexpired Foreign Passport', i94_number: '123456789t6', passport_number: 'N000000',
-        expiration_date: Date.today.to_s }
+      {
+        subject: 'I-94 (Arrival/Departure Record) in Unexpired Foreign Passport',
+        i94_number: '123456789t6',
+        passport_number: 'N000000',
+        expiration_date: Date.today.to_s,
+        country_of_citizenship: 'United States'
+      }
     end
 
     context 'for success case' do
@@ -605,7 +615,7 @@ RSpec.describe AcaEntities::Fdsh::Vlp::H92::VlpV37Contract, type: :model, dbclea
 
   context "Unexpired Foreign Passport" do
     let(:valid_params) do
-      { subject: 'Unexpired Foreign Passport', passport_number: 'N000000', expiration_date: Date.today.to_s }
+      { subject: 'Unexpired Foreign Passport', passport_number: 'N000000', expiration_date: Date.today.to_s, country_of_citizenship: 'United States' }
     end
 
     context 'for success case' do


### PR DESCRIPTION
[IVl Product Development - 186143280](https://www.pivotaltracker.com/story/show/186143280)

Makes `country_of_citizenship` a required field for the below VLP documents of subjects:
1. Machine Readable Immigrant Visa (with Temporary I-551 Language)
2. I-94 (Arrival/Departure Record) in Unexpired Foreign Passport
3. Unexpired Foreign Passport
