### PR TITLE
adds 2.6 series testing to the testing matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ['2.7.6', '3.0.5', '3.1.4', '3.2.2']
+        ruby_version: ['2.6.3', '2.7.6', '3.0.5', '3.1.4', '3.2.2']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
[IVL Product Development - 186384710](https://www.pivotaltracker.com/story/show/186384710)

Adds 2.6 series testing to the testing matrix to support the Enroll Ruby version(`2.6.3`).