### PR TITLE
create ConsumerRoleReference struct

### DIFF
--- a/lib/aca_entities/people/resident_role_reference.rb
+++ b/lib/aca_entities/people/resident_role_reference.rb
@@ -3,7 +3,10 @@
 module AcaEntities
   module People
     class ResidentRoleReference < Dry::Struct
-
+      attribute :is_applicant, Types::Bool.optional.meta(omittable: true)
+      attribute :is_active, Types::Bool.optional.meta(omittable: false)
+      attribute :is_state_resident, Types::Bool.optional.meta(omittable: false)
+      attribute :residency_determined_at, Types::Date.optional.meta(omittable: true)
     end
   end
 end

--- a/lib/aca_entities/people/resident_role_reference.rb
+++ b/lib/aca_entities/people/resident_role_reference.rb
@@ -3,8 +3,8 @@
 module AcaEntities
   module People
     class ResidentRoleReference < Dry::Struct
-      attribute :is_applicant, Types::Bool.optional.meta(omittable: true)
-      attribute :is_active, Types::Bool.optional.meta(omittable: false)
+      attribute :is_active, Types::Bool.optional.meta(omittable: true)
+      attribute :is_applicant, Types::Bool.optional.meta(omittable: false)
       attribute :is_state_resident, Types::Bool.optional.meta(omittable: false)
       attribute :residency_determined_at, Types::Date.optional.meta(omittable: true)
     end

--- a/spec/aca_entities/people/resident_role_reference_spec.rb
+++ b/spec/aca_entities/people/resident_role_reference_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::AcaEntities::People::ResidentRoleReference, dbclean: :after_each do
+
+  let(:event_response) do
+    [
+      {
+        received_at: DateTime.now,
+        body: "response"
+      }
+    ]
+  end
+
+  let(:event_request) do
+    [
+      {
+        requested_at: DateTime.now,
+        body: "request"
+      }
+    ]
+  end
+
+  let(:input_params) do
+    {
+      is_active: true,
+      is_applicant: true,
+      is_state_resident: true,
+      residency_determined_at: Date.today
+    }
+  end
+
+  describe 'with valid arguments' do
+
+    it 'should initialize' do
+      expect(described_class.new(input_params)).to be_a described_class
+    end
+
+    it 'should not raise error' do
+      expect { described_class.new(input_params) }.not_to raise_error
+    end
+  end
+
+  describe 'with invalid arguments' do
+    it 'should raise error' do
+      expect do
+        described_class.new(input_params.reject do |k, _v|
+                              k == :is_applicant
+                            end)
+      end.to raise_error(Dry::Struct::Error, /:is_applicant is missing/)
+    end
+  end
+
+  describe 'with nil is_active' do
+    it "should not raise an error" do
+      input_params.merge(is_active: nil)
+      expect { described_class.new(input_params) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/186384928

Related to https://github.com/ideacrew/enroll/pull/3309

Creates the struct similar to the [consumer_role](https://github.com/ideacrew/aca_entities/blob/ef5830c506278b4e57bd3c8f79c9ffe2875b1c9c/lib/aca_entities/people/consumer_role_reference.rb) for resident_role.

The attributes are copied from the [contract](https://github.com/ideacrew/aca_entities/blob/dade32659405d7cce1b9b5d9c637fd953e28d0fd/lib/aca_entities/contracts/people/resident_role_reference_contract.rb)
