### PR TITLE
relaxes the value requirements for optional fields

### DIFF
--- a/lib/aca_entities/contracts/verifications/verification_type_history_element_contract.rb
+++ b/lib/aca_entities/contracts/verifications/verification_type_history_element_contract.rb
@@ -15,10 +15,10 @@ module AcaEntities
         # @option opts [Hash] :event_request_record optional
         # @return [Dry::Monads::Result]
         params do
-          optional(:verification_type).filled(:string)
-          optional(:action).filled(:string)
-          optional(:modifier).filled(:string)
-          optional(:update_reason).filled(:string)
+          optional(:verification_type).maybe(:string)
+          optional(:action).maybe(:string)
+          optional(:modifier).maybe(:string)
+          optional(:update_reason).maybe(:string)
           optional(:event_response_record).hash(AcaEntities::Contracts::Events::EventResponseContract.params)
           optional(:event_request_record).hash(AcaEntities::Contracts::Events::EventRequestContract.params)
         end

--- a/spec/aca_entities/contracts/verifications/verification_type_history_element_contract_spec.rb
+++ b/spec/aca_entities/contracts/verifications/verification_type_history_element_contract_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ::AcaEntities::Contracts::Verifications::VerificationTypeHistoryE
     { verification_type: nil,
       action: nil,
       modifier: nil,
-      update_reason: nil}
+      update_reason: nil }
   end
 
   context 'success case' do

--- a/spec/aca_entities/contracts/verifications/verification_type_history_element_contract_spec.rb
+++ b/spec/aca_entities/contracts/verifications/verification_type_history_element_contract_spec.rb
@@ -13,39 +13,31 @@ RSpec.describe ::AcaEntities::Contracts::Verifications::VerificationTypeHistoryE
       event_request_record: {} }
   end
 
+  let(:optional_params) do
+    { verification_type: nil,
+      action: nil,
+      modifier: nil,
+      update_reason: nil}
+  end
+
   context 'success case' do
     before do
       @result = subject.call(required_params)
+      @result_with_nil_values = subject.call(optional_params)
     end
 
     it 'should return success' do
       expect(@result.success?).to be_truthy
+      expect(@result_with_nil_values.success?).to be_truthy
     end
 
     it 'should not have any errors' do
       expect(@result.errors.empty?).to be_truthy
+      expect(@result_with_nil_values.errors.empty?).to be_truthy
     end
   end
 
   context 'failure case' do
-    context 'missing required param' do
-      before do
-        @result = subject.call(required_params.reject { |k, _v| k == :verification_type })
-      end
-
-      it 'should return failure' do
-        # expect(@result.failure?).to be_truthy
-      end
-
-      it 'should have any errors' do
-        # expect(@result.errors.empty?).to be_falsy
-      end
-
-      it 'should return error message' do
-        # expect(@result.errors.messages.first.text).to eq('is missing')
-      end
-    end
-
     context 'with bad input data type' do
       before do
         @result = subject.call(required_params.merge(event_response_record: nil))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186497137

The contract had the values required where we want them to be optional even when the key is present.

Here are the docs for reference: https://dry-rb.org/gems/dry-schema/1.9/basics/macros/#maybe
