### PR TITLE
update family to include determination

### DIFF
--- a/lib/aca_entities/contracts/families/family_contract.rb
+++ b/lib/aca_entities/contracts/families/family_contract.rb
@@ -50,6 +50,7 @@ module AcaEntities
           optional(:updated_by).hash(AcaEntities::Contracts::People::PersonReferenceContract.params)
           optional(:timestamp).hash(TimeStampContract.params)
           optional(:documents_needed).maybe(:bool)
+          optional(:eligibility_determination).hash(AcaEntities::Eligibilities::Contracts::DeterminationContract.params)
         end
 
         # Need to have below rule and cannot move all MagiMedicaidApplication level rules to AcaEntities::Contracts::Contract because

--- a/lib/aca_entities/contracts/verifications/verification_type_contract.rb
+++ b/lib/aca_entities/contracts/verifications/verification_type_contract.rb
@@ -30,6 +30,8 @@ module AcaEntities
           optional(:updated_by).hash(AcaEntities::Contracts::People::PersonReferenceContract.params)
           optional(:inactive).maybe(:bool)
           optional(:vlp_documents).array(AcaEntities::Contracts::Documents::VlpDocumentContract.params)
+          optional(:from_validation_status).maybe(:string)
+          optional(:to_validation_status).maybe(:string)
         end
       end
     end

--- a/lib/aca_entities/families/family.rb
+++ b/lib/aca_entities/families/family.rb
@@ -62,6 +62,7 @@ module AcaEntities
       attribute :timestamp,                         AcaEntities::TimeStamp.optional.meta(omittable: true)
       attribute :documents_needed,                  Types::Bool.optional.meta(omittable: true)
       attribute :policies,                  Types::Array.of(AcaEntities::Policies::Policy).optional.meta(omittable: true)
+      attribute :eligibility_determination,         AcaEntities::Eligibilities::Determination.optional.meta(omittable: true)
 
       # policy_id is a unique identifier to find AcaEntities::InsurancePolicies::AcaIndividuals::InsurancePolicy
       def find_policy_by(policy_id)

--- a/lib/aca_entities/verifications/verification_type.rb
+++ b/lib/aca_entities/verifications/verification_type.rb
@@ -17,6 +17,8 @@ module AcaEntities
 
       attribute :vlp_documents,
                 Types::Strict::Array.of(AcaEntities::Documents::VlpDocument).optional.meta(omittable: true)
+      attribute :from_validation_status,                     Types::String.optional.meta(omittable: true)
+      attribute :to_validation_status,                       Types::String.optional.meta(omittable: true)
     end
   end
 end

--- a/spec/aca_entities/contracts/families/family_contract_spec.rb
+++ b/spec/aca_entities/contracts/families/family_contract_spec.rb
@@ -783,6 +783,29 @@ RSpec.describe AcaEntities::Contracts::Families::FamilyContract,  dbclean: :afte
     end
   end
 
+  context 'include family eligibility determination' do
+    let(:subjects) { { subjects: {} } }
+    let(:eligibility_params) do
+      {
+        subjects: subjects,
+        effective_date: Date.today,
+        outstanding_verification_status: 'not_enrolled',
+        outstanding_verification_earliest_due_date: Date.today + 30,
+        outstanding_verification_document_status: 'Partially Uploaded',
+        grants: []
+      }
+    end
+
+    before do
+      @result = subject.call(required_params.merge(eligibility_determination: eligibility_params))
+    end
+
+    it 'should return success' do
+      expect(@result.success?).to be_truthy
+      expect(@result[:eligibility_determination]).to eq eligibility_params
+    end
+  end
+
   context 'failure case' do
     context 'missing required param' do
       before do

--- a/spec/aca_entities/contracts/verifications/verification_type_contract_spec.rb
+++ b/spec/aca_entities/contracts/verifications/verification_type_contract_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe ::AcaEntities::Contracts::Verifications::VerificationTypeContract
       due_date_type: nil,
       updated_by: person_reference,
       inactive: nil,
-      vlp_documents: []
+      vlp_documents: [],
+      from_validation_status: "outstanding",
+      to_validation_status: "attested"
     }
   end
 

--- a/spec/aca_entities/families/family_spec.rb
+++ b/spec/aca_entities/families/family_spec.rb
@@ -838,5 +838,27 @@ RSpec.describe AcaEntities::Families::Family, dbclean: :after_each do
         expect(family.find_policy_by('policy_id')).to be_nil
       end
     end
+
+    context 'include family eligibility determination' do
+      let(:subjects) { { subjects: {} } }
+      let(:eligibility_params) do
+        {
+          subjects: subjects,
+          effective_date: Date.today,
+          outstanding_verification_status: 'not_enrolled',
+          outstanding_verification_earliest_due_date: Date.today + 30,
+          outstanding_verification_document_status: 'Partially Uploaded',
+          grants: []
+        }
+      end
+
+      before do
+        @result = described_class.call(input_params.merge(eligibility_determination: eligibility_params))
+      end
+
+      it 'should return AcaEntities::Families::Family' do
+        expect(@result.class).to eq AcaEntities::Families::Family
+      end
+    end
   end
 end

--- a/spec/aca_entities/verifications/verification_type_spec.rb
+++ b/spec/aca_entities/verifications/verification_type_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe ::AcaEntities::Verifications::VerificationType, dbclean: :after_e
       due_date_type: nil,
       updated_by: person_reference,
       inactive: nil,
-      vlp_documents: []
+      vlp_documents: [],
+      from_validation_status: "outstanding",
+      to_validation_status: "attested"
     }
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187563523

# A brief description of the changes

Current behavior: family does not include determination

New behavior: Add determination in family as an optional param.

# Additional Context
Include any additional context that may be relevant to the peer review process.

