### PR TITLE
adds dmf requested subscriber on fdsh_gateway

### DIFF
--- a/lib/aca_entities/async_api/fdsh_gateway/amqp_family_dmf_determination_subscriber.yml
+++ b/lib/aca_entities/async_api/fdsh_gateway/amqp_family_dmf_determination_subscriber.yml
@@ -1,0 +1,56 @@
+---
+asyncapi: 2.0.0
+info:
+  title: Enroll App
+  version: 0.1.0
+  description: AMQP Subscribe configuration for the Enroll App services
+  contact:
+    name: IdeaCrew
+    url: https://ideacrew.com
+    email: info@ideacrew.com
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+servers:
+  production:
+    url: "amqp://rabbitmq:5672/event_source"
+    protocol: :amqp
+    protocolVersion: "0.9.2"
+    description: RabbitMQ Production Server
+  development:
+    url: "amqp://rabbitmq:5672/event_source"
+    protocol: :amqp
+    protocolVersion: "0.9.2"
+    description: RabbitMQ Test Server
+  test:
+    url: "amqp://rabbitmq:5672/event_source"
+    protocol: :amqp
+    protocolVersion: "0.9.2"
+    description: RabbitMQ Test Server
+
+channels:
+  on_fdsh_gateway.enroll.families.verifications.dmf_determination:
+    bindings:
+      amqp:
+        is: queue
+        queue:
+          name: on_fdsh_gateway.enroll.families.verifications.dmf_determination
+          durable: true
+          exclusive: false
+          auto_delete: false
+          vhost: event_source
+    subscribe:
+      bindings:
+        amqp:
+          ack: true
+          exclusive: false
+          routing_key: enroll.families.verifications.dmf_determination.requested
+          prefetch: 1
+          bindingVersion: "0.2.0"
+      operationId: on_fdsh_gateway.enroll.families.verifications.dmf_determination
+      description: Events - Subscriber to publish dmf determination request for individual family
+
+tags:
+  - name: linter_tag
+    description: placeholder that satisfies the linter

--- a/lib/aca_entities/async_api/fdsh_gateway/amqp_family_dmf_determination_subscriber.yml
+++ b/lib/aca_entities/async_api/fdsh_gateway/amqp_family_dmf_determination_subscriber.yml
@@ -49,7 +49,7 @@ channels:
           prefetch: 1
           bindingVersion: "0.2.0"
       operationId: on_fdsh_gateway.enroll.families.verifications.dmf_determination
-      description: Events - Subscriber to publish dmf determination request for individual family
+      description: Events - Subscriber to consume dmf determination request for individual family
 
 tags:
   - name: linter_tag


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/187597397

# A brief description of the changes

New behavior:  DMF Subscriber configs to consume events in FDSH_Gateway

# Additional Context
Include any additional context that may be relevant to the peer review process.

