### PR TITLE
adding is gap filling to product elig determination

### DIFF
--- a/lib/aca_entities/magi_medicaid/contracts/product_eligibility_determination_contract.rb
+++ b/lib/aca_entities/magi_medicaid/contracts/product_eligibility_determination_contract.rb
@@ -41,6 +41,7 @@ module AcaEntities
 
           optional(:is_non_magi_medicaid_eligible).maybe(:bool)
           optional(:is_without_assistance).maybe(:bool)
+          optional(:is_gap_filling).maybe(:bool)
 
           optional(:magi_medicaid_monthly_household_income).maybe(Types::Money)
           optional(:medicaid_household_size).maybe(:integer)

--- a/lib/aca_entities/magi_medicaid/product_eligibility_determination.rb
+++ b/lib/aca_entities/magi_medicaid/product_eligibility_determination.rb
@@ -14,6 +14,7 @@ module AcaEntities
       attribute :csr, Types::CsrKind.optional.meta(omittable: true)
 
       attribute :is_non_magi_medicaid_eligible, Types::Bool.optional.meta(omittable: true)
+      attribute :is_gap_filling, Types::Bool.optional.meta(omittable: true)
       attribute :is_without_assistance, Types::Bool.optional.meta(omittable: true)
 
       attribute :magi_medicaid_monthly_household_income, Types::Money.optional.meta(omittable: true)

--- a/spec/aca_entities/magi_medicaid/contracts/product_eligibility_determination_contract_spec.rb
+++ b/spec/aca_entities/magi_medicaid/contracts/product_eligibility_determination_contract_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::Contracts::ProductEligibilityDetermi
       medicaid_household_size: 1,
       magi_medicaid_monthly_income_limit: 3760.67,
       magi_as_percentage_of_fpl: 10.0,
+      is_gap_filling: true,
       magi_medicaid_category: 'parent_caretaker'
     }
   end

--- a/spec/aca_entities/magi_medicaid/product_eligibility_determination_spec.rb
+++ b/spec/aca_entities/magi_medicaid/product_eligibility_determination_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ::AcaEntities::MagiMedicaid::ProductEligibilityDetermination do
       magi_medicaid_monthly_income_limit: 3760.67,
       magi_as_percentage_of_fpl: 10.0,
       magi_medicaid_category: 'parent_caretaker',
+      is_gap_filling: true,
       magi_medicaid_ineligibility_reasons: ['dummy reason'] }
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?
introduce is gap filling
- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187862378

# A brief description of the changes

Current behavior:

New behavior: supports is gap filling

# Additional Context
Include any additional context that may be relevant to the peer review process.

