### PR TITLE
set indian_tribe_member attribute on person hash in ATP inbound process

### DIFF
--- a/lib/aca_entities/atp/transformers/cv/family.rb
+++ b/lib/aca_entities/atp/transformers/cv/family.rb
@@ -116,6 +116,10 @@ module AcaEntities
                     return nil unless tribe_indicator
                     tribal_augmentation[:person_tribe_name]
                   }
+                  add_key 'person.person_demographics.indian_tribe_member', function: lambda { |v|
+                    tribal_augmentation = v.find(Regexp.new('record.people.*.tribal_augmentation')).map(&:item).last
+                    tribal_augmentation[:american_indian_or_alaska_native_indicator]
+                  }
                   map 'augementation', 'augementation', memoize_record: true, visible: false
                   add_key 'person.addresses', memoize_record: true, function: AcaEntities::Atp::Functions::AddressBuilder.new
                   add_key 'person.is_homeless', function: lambda { |v|

--- a/spec/aca_entities/atp/transformers/person_ai_an_indicator_spec.rb
+++ b/spec/aca_entities/atp/transformers/person_ai_an_indicator_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require 'aca_entities/serializers/xml/medicaid/atp'
+require 'aca_entities/atp/transformers/cv/family'
+require 'aca_entities/medicaid/atp'
+require 'aca_entities/medicaid/contracts/account_transfer_request_contract'
+require 'aca_entities/atp/transformers/aces/family'
+require 'aca_entities/atp/operations/aces/generate_xml'
+require 'aca_entities/serializers/xml/medicaid/atp/account_transfer_request'
+require "support/atp/inbound_build_application"
+require "aca_entities/atp/transformers/cv/phone"
+require "aca_entities/atp/transformers/cv/other_questions"
+require "aca_entities/atp/transformers/cv/deduction"
+require "aca_entities/atp/transformers/cv/income"
+require "aca_entities/atp/transformers/cv/contact_info"
+require "aca_entities/atp/functions/lawful_presence_determination_builder"
+require "aca_entities/atp/functions/address_builder"
+require "aca_entities/functions/age_on"
+require "aca_entities/atp/functions/relationship_builder"
+
+RSpec.describe AcaEntities::Atp, "given an inbound XML with person level PersonAmericanIndianOrAlaskaNativeIndicator data" do
+
+  context "when PersonAmericanIndianOrAlaskaNativeIndicator is false for a person" do
+    let(:payload) do
+      File.read(Pathname.pwd.join("spec/support/atp/sample_payloads/sample_incarceration_payload.xml"))
+    end
+
+    let(:document) do
+      document = Nokogiri::XML(payload)
+      document.xpath('//hix-core:PersonAmericanIndianOrAlaskaNativeIndicator', 'hix-core' => "http://hix.cms.gov/0.1/hix-core")[1].remove
+      document
+    end
+
+    let(:account_transfer_request) do
+      ::AcaEntities::Serializers::Xml::Medicaid::Atp::AccountTransferRequest.parse(document.root.canonicalize, :single => true)
+    end
+
+    before do
+      @transformed = ::AcaEntities::Atp::Transformers::Cv::Family.transform(account_transfer_request.to_hash(identifier: true))
+      @applicants = @transformed[:family][:magi_medicaid_applications].first[:applicants]
+      @family_members = @transformed[:family][:family_members]
+    end
+
+    it "should set indian_tribe_member as false on person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000190"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Rob/)
+      end
+      expect(applicant[:indian_tribe_member]).to eq false
+      expect(member[:person][:person_demographics][:indian_tribe_member]).to eq false
+    end
+
+    it "should set tribal_name to nil for person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000190"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Rob/)
+      end
+      expect(applicant[:tribal_name]).to eq nil
+      expect(member[:person][:person_demographics][:tribal_name]).to eq nil
+    end
+
+    it "should set tribal_state to nil for person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000190"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Rob/)
+      end
+      expect(applicant[:tribal_state]).to eq nil
+      expect(member[:person][:person_demographics][:tribal_state]).to eq nil
+    end
+  end
+
+  context "when PersonAmericanIndianOrAlaskaNativeIndicator is true for a person" do
+    let(:payload) do
+      File.read(Pathname.pwd.join("spec/support/atp/sample_payloads/sample_incarceration_payload.xml"))
+    end
+
+    let(:document) do
+      document = Nokogiri::XML(payload)
+      document.xpath('//hix-core:PersonAmericanIndianOrAlaskaNativeIndicator', 'hix-core' => "http://hix.cms.gov/0.1/hix-core")[0].remove
+      document
+    end
+
+    let(:account_transfer_request) do
+      ::AcaEntities::Serializers::Xml::Medicaid::Atp::AccountTransferRequest.parse(document.root.canonicalize, :single => true)
+    end
+
+    before do
+      @transformed = ::AcaEntities::Atp::Transformers::Cv::Family.transform(account_transfer_request.to_hash(identifier: true))
+      @applicants = @transformed[:family][:magi_medicaid_applications].first[:applicants]
+      @family_members = @transformed[:family][:family_members]
+    end
+
+    it "should set indian_tribe_member as true on person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000191"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Nancy/)
+      end
+      expect(applicant[:indian_tribe_member]).to eq true
+      expect(member[:person][:person_demographics][:indian_tribe_member]).to eq true
+    end
+
+    it "should set tribal_name for person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000191"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Nancy/)
+      end
+      expect(applicant[:tribal_name]).to eq "Eastern Band of Cherokee Indians of North Carolina"
+      expect(member[:person][:person_demographics][:tribal_name]).to eq "Eastern Band of Cherokee Indians of North Carolina"
+    end
+
+    it "should set tribal_state for person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000191"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Nancy/)
+      end
+      expect(applicant[:tribal_state]).to eq "ME"
+      expect(member[:person][:person_demographics][:tribal_state]).to eq "ME"
+    end
+  end
+
+  context "when PersonAmericanIndianOrAlaskaNativeIndicator element does not exist for a person" do
+    let(:payload) do
+      File.read(Pathname.pwd.join("spec/support/atp/sample_payloads/sample_incarceration_payload.xml"))
+    end
+
+    let(:document) do
+      document = Nokogiri::XML(payload)
+      document.xpath('//hix-core:PersonAmericanIndianOrAlaskaNativeIndicator', 'hix-core' => "http://hix.cms.gov/0.1/hix-core").each(&:remove)
+      document
+    end
+
+    let(:account_transfer_request) do
+      ::AcaEntities::Serializers::Xml::Medicaid::Atp::AccountTransferRequest.parse(document.root.canonicalize, :single => true)
+    end
+
+    before do
+      @transformed = ::AcaEntities::Atp::Transformers::Cv::Family.transform(account_transfer_request.to_hash(identifier: true))
+      @applicants = @transformed[:family][:magi_medicaid_applications].first[:applicants]
+      @family_members = @transformed[:family][:family_members]
+    end
+
+    it "should set indian_tribe_member as nil on person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000191"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Nancy/)
+      end
+      expect(applicant[:indian_tribe_member]).to eq nil
+      expect(member[:person][:person_demographics][:indian_tribe_member]).to eq nil
+    end
+
+    it "should set tribal_name to nil for person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000191"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Nancy/)
+      end
+      expect(applicant[:tribal_name]).to eq nil
+      expect(member[:person][:person_demographics][:tribal_name]).to eq nil
+    end
+
+    it "should set tribal_state to nil for person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000191"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Nancy/)
+      end
+      expect(applicant[:tribal_state]).to eq nil
+      expect(member[:person][:person_demographics][:tribal_state]).to eq nil
+    end
+  end
+end

--- a/spec/support/atp/sample_payloads/sample_incarceration_payload.xml
+++ b/spec/support/atp/sample_payloads/sample_incarceration_payload.xml
@@ -301,7 +301,10 @@
     </nc:PersonSSNIdentification>
     <nc:PersonUSCitizenIndicator>false</nc:PersonUSCitizenIndicator>
     <hix-core:TribalAugmentation>
-      <hix-core:PersonAmericanIndianOrAlaskaNativeIndicator>false</hix-core:PersonAmericanIndianOrAlaskaNativeIndicator>
+      <hix-core:PersonRecognizedTribeIndicator>true</hix-core:PersonRecognizedTribeIndicator>
+      <hix-core:PersonAmericanIndianOrAlaskaNativeIndicator>true</hix-core:PersonAmericanIndianOrAlaskaNativeIndicator>
+      <hix-core:PersonTribeName>Eastern Band of Cherokee Indians of North Carolina</hix-core:PersonTribeName>
+      <nc:LocationStateUSPostalServiceCode>ME</nc:LocationStateUSPostalServiceCode>
     </hix-core:TribalAugmentation>
     <hix-core:PersonAugmentation>
       <hix-core:PersonAssociation>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187861724

# A brief description of the changes

Current behavior: Indian Tribe member status is not being set on person hash in ATP inbound process

New behavior: Set Indian Tribe member status on person hash in ATP inbound process

# Additional Context
Include any additional context that may be relevant to the peer review process.

