### PR TITLE
make phone and email optional in account contract and entity

### DIFF
--- a/lib/aca_entities/crm/account.rb
+++ b/lib/aca_entities/crm/account.rb
@@ -15,7 +15,7 @@ module AcaEntities
 
       # @!attribute [r] email1
       #   @return [String] primary email address
-      attribute :email1, AcaEntities::Crm::Types::Email.meta(omittable: false)
+      attribute :email1, AcaEntities::Crm::Types::Email.optional.meta(omittable: true)
 
       # @!attribute [r] billing_address_street
       #   @return [String] street address for billing
@@ -47,7 +47,7 @@ module AcaEntities
 
       # @!attribute [r] phone_office
       #   @return [String] office phone number
-      attribute :phone_office, AcaEntities::Crm::Types::Phone.meta(omittable: false)
+      attribute :phone_office, AcaEntities::Crm::Types::Phone.optional.meta(omittable: true)
 
       # @!attribute [r] rawssn_c
       #   @return [String] Social Security Number

--- a/lib/aca_entities/crm/contracts/account_contract.rb
+++ b/lib/aca_entities/crm/contracts/account_contract.rb
@@ -10,7 +10,7 @@ module AcaEntities
       #   @param opts [Hash] the parameters to validate using this contract
       #   @option opts [String] :hbxid_c required
       #   @option opts [String] :name required
-      #   @option opts [String] :email1 required
+      #   @option opts [String] :email1 optional
       #   @option opts [String] :billing_address_street required
       #   @option opts [String] :billing_address_street2 optional
       #   @option opts [String] :billing_address_street3 optional
@@ -18,7 +18,7 @@ module AcaEntities
       #   @option opts [String] :billing_address_city required
       #   @option opts [String] :billing_address_postalcode required
       #   @option opts [String] :billing_address_state required
-      #   @option opts [String] :phone_office required
+      #   @option opts [String] :phone_office optional
       #   @option opts [String] :rawssn_c required
       #   @option opts [String] :raw_ssn_c required
       #   @option opts [Date] :dob_c required

--- a/lib/aca_entities/crm/contracts/account_contract.rb
+++ b/lib/aca_entities/crm/contracts/account_contract.rb
@@ -28,7 +28,7 @@ module AcaEntities
         params do
           required(:hbxid_c).filled(Types::Coercible::String)
           required(:name).filled(Types::Coercible::String)
-          required(:email1).filled(AcaEntities::Crm::Types::Email)
+          optional(:email1).maybe(AcaEntities::Crm::Types::Email)
           required(:billing_address_street).filled(Types::Coercible::String)
           optional(:billing_address_street2).maybe(Types::Coercible::String)
           optional(:billing_address_street3).maybe(Types::Coercible::String)
@@ -36,7 +36,7 @@ module AcaEntities
           required(:billing_address_city).filled(Types::Coercible::String)
           required(:billing_address_postalcode).filled(Types::Coercible::String)
           required(:billing_address_state).filled(Types::Coercible::String)
-          required(:phone_office).filled(AcaEntities::Crm::Types::Phone)
+          optional(:phone_office).maybe(AcaEntities::Crm::Types::Phone)
           optional(:rawssn_c).maybe(AcaEntities::Crm::Types::SSN)
           required(:raw_ssn_c).filled(AcaEntities::Crm::Types::SSN)
           required(:dob_c).filled(AcaEntities::Crm::Types::Dob)

--- a/spec/aca_entities/crm/account_spec.rb
+++ b/spec/aca_entities/crm/account_spec.rb
@@ -25,12 +25,10 @@ RSpec.describe ::AcaEntities::Crm::Account do
     {
       hbxid_c: '12345',
       name: 'John Doe',
-      email1: email,
       billing_address_street: '123 Main St',
       billing_address_city: 'Anytown',
       billing_address_postalcode: '12345',
       billing_address_state: 'ST',
-      phone_office: phone,
       raw_ssn_c: ssn,
       dob_c: (Date.today - 10_000).to_s,
       contacts: [contact]
@@ -43,7 +41,9 @@ RSpec.describe ::AcaEntities::Crm::Account do
       billing_address_street3: 'Floor 2',
       billing_address_street4: 'Suite 3',
       rawssn_c: ssn,
-      enroll_account_link_c: 'http://example.com/account'
+      enroll_account_link_c: 'http://example.com/account',
+      phone_office: phone,
+      email1: email
     }
   end
 
@@ -108,6 +108,40 @@ RSpec.describe ::AcaEntities::Crm::Account do
 
       it 'returns false' do
         expect(account1.account_same_as?(account2)).to be_falsey
+      end
+    end
+
+    context "with blank emails" do
+
+      let(:email) { nil }
+
+      let(:account_contract) { AcaEntities::Crm::Contracts::AccountContract.new.call(account_params) }
+
+      let(:account_entity) { described_class.new(account_contract.to_h) }
+
+      it "sucessfully passes account contact" do
+        expect(account_contract.success?).to be_truthy
+      end
+
+      it "returns an account entity object" do
+        expect(account_entity).to be_a(described_class)
+      end
+    end
+
+    context "with blank phones" do
+
+      let(:phone) { nil }
+
+      let(:account_contract) { AcaEntities::Crm::Contracts::AccountContract.new.call(account_params) }
+
+      let(:account_entity) { described_class.new(account_contract.to_h) }
+
+      it "sucessfully passes account contact" do
+        expect(account_contract.success?).to be_truthy
+      end
+
+      it "returns an account entity object" do
+        expect(account_entity).to be_a(described_class)
       end
     end
   end

--- a/spec/aca_entities/crm/contracts/account_contract_spec.rb
+++ b/spec/aca_entities/crm/contracts/account_contract_spec.rb
@@ -118,7 +118,6 @@ RSpec.describe AcaEntities::Crm::Contracts::AccountContract do
     let(:phone) { nil }
 
     it "passes validation" do
-
       expect(subject.call(all_values).success?).to be true
     end
   end

--- a/spec/aca_entities/crm/contracts/account_contract_spec.rb
+++ b/spec/aca_entities/crm/contracts/account_contract_spec.rb
@@ -27,12 +27,10 @@ RSpec.describe AcaEntities::Crm::Contracts::AccountContract do
     {
       hbxid_c: '12345',
       name: 'John Doe',
-      email1: email,
       billing_address_street: '123 Main St',
       billing_address_city: 'Anytown',
       billing_address_postalcode: '12345',
       billing_address_state: 'ST',
-      phone_office: phone,
       raw_ssn_c: ssn,
       dob_c: (Date.today - 10_000).to_s,
       contacts: [contact]
@@ -41,6 +39,8 @@ RSpec.describe AcaEntities::Crm::Contracts::AccountContract do
 
   let(:optional_values) do
     {
+      email1: email,
+      phone_office: phone,
       billing_address_street2: 'Apt 1',
       billing_address_street3: 'Floor 2',
       billing_address_street4: 'Suite 3',
@@ -78,7 +78,7 @@ RSpec.describe AcaEntities::Crm::Contracts::AccountContract do
     let(:email) { 'john.example.com' }
 
     it 'fails validation' do
-      result = subject.call(required_values)
+      result = subject.call(all_values)
       expect(result.failure?).to be true
       expect(result.errors.to_h[:email1]).to include('is in invalid format')
     end
@@ -88,7 +88,7 @@ RSpec.describe AcaEntities::Crm::Contracts::AccountContract do
     let(:phone) { '123-456-7890' }
 
     it 'fails validation' do
-      result = subject.call(required_values)
+      result = subject.call(all_values)
       expect(result.failure?).to be true
       expect(result.errors.to_h[:phone_office]).to include('is in invalid format')
     end
@@ -98,7 +98,7 @@ RSpec.describe AcaEntities::Crm::Contracts::AccountContract do
     let(:phone) { Date.today }
 
     it 'fails validation' do
-      result = subject.call(required_values)
+      result = subject.call(all_values)
       expect(result.failure?).to be true
       expect(result.errors.to_h[:phone_office]).to include('must be a string')
     end
@@ -111,6 +111,24 @@ RSpec.describe AcaEntities::Crm::Contracts::AccountContract do
       result = subject.call(required_values)
       expect(result.failure?).to be true
       expect(result.errors.to_h[:raw_ssn_c]).to include('is in invalid format')
+    end
+  end
+
+  context "with blank phone number" do
+    let(:phone) { nil }
+
+    it "passes validation" do
+      binding.irb
+      expect(subject.call(all_values).success?).to be true
+    end
+  end
+
+  context "with blank email" do
+    let(:email) { nil }
+
+    it "passes validation" do
+      binding.irb
+      expect(subject.call(all_values).success?).to be true
     end
   end
 end

--- a/spec/aca_entities/crm/contracts/account_contract_spec.rb
+++ b/spec/aca_entities/crm/contracts/account_contract_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe AcaEntities::Crm::Contracts::AccountContract do
     let(:phone) { nil }
 
     it "passes validation" do
-      binding.irb
+
       expect(subject.call(all_values).success?).to be true
     end
   end
@@ -127,7 +127,6 @@ RSpec.describe AcaEntities::Crm::Contracts::AccountContract do
     let(:email) { nil }
 
     it "passes validation" do
-      binding.irb
       expect(subject.call(all_values).success?).to be true
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/188029538#

# A brief description of the changes

Current behavior: When phones or emails are blank the account contract is failing

New behavior: Make phones or emails optional so they don't fail the account contract

# Additional Context
Include any additional context that may be relevant to the peer review process.

