### PR TITLE
handle other document types in atp outbound process

### DIFF
--- a/lib/aca_entities/atp/functions/immigration_document_builder.rb
+++ b/lib/aca_entities/atp/functions/immigration_document_builder.rb
@@ -41,9 +41,9 @@ module AcaEntities
           when 'DS2019 (Certificate of Eligibility for Exchange Visitor (J-1) Status)'
             doc = ds2019_doc
           when 'Other (with alien number)'
-            # Uncertain mapping to XML
+            doc = other_with_alien_number_doc
           when 'Other (with I-94 number)'
-            # Uncertain mapping to XML
+            doc = other_with_i94_doc
           end
 
           [doc]
@@ -179,6 +179,28 @@ module AcaEntities
           @document_person_ids << passport_number if passport_number
           {
             category_code: 'DS2019',
+            expiration_date: expiration_date,
+            document_person_ids: @document_person_ids
+          }
+        end
+
+        def other_with_i94_doc
+          @document_person_ids << i94_number if i94_number
+          @document_person_ids << passport_number if passport_number
+          @document_person_ids << sevis_id if sevis_id
+          {
+            category_text: 'Other (with I-94 number)',
+            expiration_date: expiration_date,
+            document_person_ids: @document_person_ids
+          }
+        end
+
+        def other_with_alien_number_doc
+          @document_person_ids << alien_number if alien_number
+          @document_person_ids << passport_number if passport_number
+          @document_person_ids << sevis_id if sevis_id
+          {
+            category_text: 'Other (with alien number)',
             expiration_date: expiration_date,
             document_person_ids: @document_person_ids
           }

--- a/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
+++ b/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
@@ -403,6 +403,48 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
           expect(tag.text).to eq "I20"
         end
       end
+
+      context 'Other (with alien number) vlp document' do
+        let(:other_with_alien_number) do
+          applicant = payload_hash[:family][:magi_medicaid_applications][:applicants][1]
+          applicant[:citizenship_immigration_status_information][:citizen_status] = 'alien_lawfully_present'
+          applicant[:vlp_document] = {}
+          applicant[:vlp_document][:subject] = 'Other (with alien number)'
+          applicant[:vlp_document][:alien_number] = '987654321'
+          applicant[:vlp_document][:passport_number] = 'M2938193'
+          applicant[:vlp_document][:sevis_id] = '4829292910'
+          applicant[:vlp_document][:expiration_date] = '2025-07-01T00:00:00.000+00:00'
+          payload_hash.to_json
+        end
+
+        it 'should populate LawfulPresenceDocumentCategoryCode tags for Other (with alien number)' do
+          result = described_class.new.call(other_with_alien_number)
+          doc = Nokogiri::XML.parse(result.value!)
+          tag = doc.xpath("//hix-ee:LawfulPresenceDocumentCategoryText", namespaces)[0]
+          expect(tag.text).to eq "Other (with alien number)"
+        end
+      end
+
+      context 'Other (with I-94 number) vlp document' do
+        let(:other_with_alien_number) do
+          applicant = payload_hash[:family][:magi_medicaid_applications][:applicants][1]
+          applicant[:citizenship_immigration_status_information][:citizen_status] = 'alien_lawfully_present'
+          applicant[:vlp_document] = {}
+          applicant[:vlp_document][:subject] = 'Other (with I-94 number)'
+          applicant[:vlp_document][:i94_number] = '9882888888O'
+          applicant[:vlp_document][:passport_number] = 'M2938193'
+          applicant[:vlp_document][:sevis_id] = '4829292910'
+          applicant[:vlp_document][:expiration_date] = '2025-07-01T00:00:00.000+00:00'
+          payload_hash.to_json
+        end
+
+        it 'should populate LawfulPresenceDocumentCategoryCode tags for Other (with I-94 number)' do
+          result = described_class.new.call(other_with_alien_number)
+          doc = Nokogiri::XML.parse(result.value!)
+          tag = doc.xpath("//hix-ee:LawfulPresenceDocumentCategoryText", namespaces)[0]
+          expect(tag.text).to eq "Other (with I-94 number)"
+        end
+      end
     end
 
     context "when annual_tax_household_income is a string" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187861518 

# A brief description of the changes

Current behavior: Other document types are not being sent as part of ATP outbound process

New behavior: Send other document types in ATP outbound process

# Additional Context
Include any additional context that may be relevant to the peer review process.

