### PR TITLE
map country of citizenship to iso code

### DIFF
--- a/lib/aca_entities/atp/functions/immigration_document_builder.rb
+++ b/lib/aca_entities/atp/functions/immigration_document_builder.rb
@@ -12,6 +12,7 @@ module AcaEntities
           @vlp_document = cache.resolve('vlp_document').item
           @document_person_ids = []
           return [] unless @vlp_document
+          @vlp_doc_entity = AcaEntities::Documents::VlpDocument.new(@vlp_document.except(:expiration_date))
 
           case @vlp_document[:subject]
           when 'I-327 (Reentry Permit)'
@@ -236,7 +237,7 @@ module AcaEntities
           {
             :identification_id => @vlp_document[:passport_number],
             :identification_category_text => "Passport Number",
-            :identification_jurisdiction => @vlp_document[:country_of_citizenship]
+            :identification_jurisdiction => @vlp_doc_entity.three_letter_country_of_citizenship
           }
         end
 

--- a/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
+++ b/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
           applicant[:vlp_document][:subject] = 'DS2019 (Certificate of Eligibility for Exchange Visitor (J-1) Status)'
           applicant[:vlp_document][:i94_number] = '9882888888O'
           applicant[:vlp_document][:passport_number] = 'M2938193'
-          applicant[:vlp_document][:country_of_citizenship] = 'Brazil'
+          applicant[:vlp_document][:country_of_citizenship] = 'India'
           applicant[:vlp_document][:sevis_id] = '4829292910'
           applicant[:vlp_document][:expiration_date] = '2025-07-01T00:00:00.000+00:00'
           payload_hash.to_json
@@ -189,7 +189,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
           doc = Nokogiri::XML.parse(result.value!)
           country = doc.xpath("//hix-ee:LawfulPresenceDocumentPersonIdentification/nc:IdentificationJurisdictionISO3166Alpha3Code",
                               namespaces)[0]
-          expect(country.text).to eq "Brazil"
+          expect(country.text).to eq "IND"
         end
 
         it "applicant should have EligibilityIndicator set to true" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/187861518

# A brief description of the changes

Current behavior: Country of Citizenship is passed as a String instead of ISO code in ATP outbound schema

New behavior: Passing ISO code for country of citizenship instead of a name string

# Additional Context
Include any additional context that may be relevant to the peer review process.

