### PR TITLE
Populate Start/End dates for Expense category in ATP outbound payload

### DIFF
--- a/lib/aca_entities/atp/functions/expense_builder.rb
+++ b/lib/aca_entities/atp/functions/expense_builder.rb
@@ -24,9 +24,19 @@ module AcaEntities
           return if deduction[:start_on].blank? && deduction[:end_on].blank?
 
           category_text = []
-          category_text << "start:#{deduction[:start_on]}" if deduction[:start_on].present?
-          category_text << "end:#{deduction[:end_on]}" if deduction[:end_on].present?
+          category_text << "start:#{format_date(deduction[:start_on])}" if deduction[:start_on].present?
+          category_text << "end:#{format_date(deduction[:end_on])}" if deduction[:end_on].present?
           category_text.join(',')
+        end
+
+        def format_date(date)
+          case date
+          when String
+            parsed_date = Date.parse(date)
+            parsed_date.iso8601
+          when Date, DateTime
+            date.to_date.iso8601
+          end
         end
       end
     end

--- a/lib/aca_entities/atp/functions/expense_builder.rb
+++ b/lib/aca_entities/atp/functions/expense_builder.rb
@@ -13,8 +13,20 @@ module AcaEntities
           deductions = applicants_hash[member_id.to_sym][:deductions]
 
           deductions.each_with_object([]) do |deduction, collect|
-            collect << ::AcaEntities::Atp::Transformers::Aces::Expense.transform(deduction)
+            result = ::AcaEntities::Atp::Transformers::Aces::Expense.transform(deduction)
+            category_text = construct_category_text(deduction)
+            result.merge!(category_text: category_text) if category_text.present?
+            collect << result
           end
+        end
+
+        def construct_category_text(deduction)
+          return if deduction[:start_on].blank? && deduction[:end_on].blank?
+
+          category_text = []
+          category_text << "start:#{deduction[:start_on]}" if deduction[:start_on].present?
+          category_text << "end:#{deduction[:end_on]}" if deduction[:end_on].present?
+          category_text.join(',')
         end
       end
     end

--- a/lib/aca_entities/atp/functions/immigration_document_builder.rb
+++ b/lib/aca_entities/atp/functions/immigration_document_builder.rb
@@ -41,9 +41,9 @@ module AcaEntities
             doc = i20_doc
           when 'DS2019 (Certificate of Eligibility for Exchange Visitor (J-1) Status)'
             doc = ds2019_doc
-          when 'Other (with alien number)'
+          when 'Other (With Alien Number)'
             doc = other_with_alien_number_doc
-          when 'Other (with I-94 number)'
+          when 'Other (With I-94 Number)'
             doc = other_with_i94_doc
           end
 
@@ -190,7 +190,7 @@ module AcaEntities
           @document_person_ids << passport_number if passport_number
           @document_person_ids << sevis_id if sevis_id
           {
-            category_text: 'Other (with I-94 number)',
+            category_text: 'Other (With I-94 Number)',
             expiration_date: expiration_date,
             document_person_ids: @document_person_ids
           }
@@ -201,7 +201,7 @@ module AcaEntities
           @document_person_ids << passport_number if passport_number
           @document_person_ids << sevis_id if sevis_id
           {
-            category_text: 'Other (with alien number)',
+            category_text: 'Other (With Alien Number)',
             expiration_date: expiration_date,
             document_person_ids: @document_person_ids
           }

--- a/lib/aca_entities/atp/transformers/aces/expense.rb
+++ b/lib/aca_entities/atp/transformers/aces/expense.rb
@@ -13,7 +13,6 @@ module AcaEntities
             'student_loan_interest' => 'StudentLoanInterest'
           }.freeze
 
-          add_key 'category_text'
           map 'amount', 'amount'
           map 'frequency_kind', 'frequency.frequency_code'
           map 'kind', 'category_code', function: lambda { |v|

--- a/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
+++ b/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
@@ -409,7 +409,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
           applicant = payload_hash[:family][:magi_medicaid_applications][:applicants][1]
           applicant[:citizenship_immigration_status_information][:citizen_status] = 'alien_lawfully_present'
           applicant[:vlp_document] = {}
-          applicant[:vlp_document][:subject] = 'Other (with alien number)'
+          applicant[:vlp_document][:subject] = 'Other (With Alien Number)'
           applicant[:vlp_document][:alien_number] = '987654321'
           applicant[:vlp_document][:passport_number] = 'M2938193'
           applicant[:vlp_document][:sevis_id] = '4829292910'
@@ -421,7 +421,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
           result = described_class.new.call(other_with_alien_number)
           doc = Nokogiri::XML.parse(result.value!)
           tag = doc.xpath("//hix-ee:LawfulPresenceDocumentCategoryText", namespaces)[0]
-          expect(tag.text).to eq "Other (with alien number)"
+          expect(tag.text).to eq "Other (With Alien Number)"
         end
       end
 
@@ -430,7 +430,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
           applicant = payload_hash[:family][:magi_medicaid_applications][:applicants][1]
           applicant[:citizenship_immigration_status_information][:citizen_status] = 'alien_lawfully_present'
           applicant[:vlp_document] = {}
-          applicant[:vlp_document][:subject] = 'Other (with I-94 number)'
+          applicant[:vlp_document][:subject] = 'Other (With I-94 Number)'
           applicant[:vlp_document][:i94_number] = '9882888888O'
           applicant[:vlp_document][:passport_number] = 'M2938193'
           applicant[:vlp_document][:sevis_id] = '4829292910'
@@ -442,7 +442,7 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
           result = described_class.new.call(other_with_alien_number)
           doc = Nokogiri::XML.parse(result.value!)
           tag = doc.xpath("//hix-ee:LawfulPresenceDocumentCategoryText", namespaces)[0]
-          expect(tag.text).to eq "Other (with I-94 number)"
+          expect(tag.text).to eq "Other (With I-94 Number)"
         end
       end
     end

--- a/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
+++ b/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
@@ -879,6 +879,32 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
           expect(category_text.present?).to eq false
         end
       end
+
+      context 'when expense start and end dates are in date format' do
+        let(:date) { Date.today }
+        let(:expense_payload) do
+          applicant_1 = payload_hash[:family][:magi_medicaid_applications][:applicants][0]
+          applicant_1[:deductions] = [
+            {
+              name: nil,
+              kind: "alimony_paid",
+              start_on: date,
+              end_on: date,
+              amount: 10.0,
+              frequency_kind: "Daily",
+              submitted_at: "2021-07-27T14:29:26.000+00:00"
+            }
+          ]
+          payload_hash.to_json
+        end
+
+        it 'should populate expense category text section' do
+          result = described_class.new.call(expense_payload)
+          doc = Nokogiri::XML.parse(result.value!)
+          category_text = doc.xpath("//hix-core:ExpenseCategoryText", namespaces)[0]
+          expect(category_text.text).to include(date.to_date.iso8601)
+        end
+      end
     end
 
     context 'param flags' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/187984509

# A brief description of the changes

Current behavior: Deduction start and end dates and not being sent as part of the ATP outbound payload as the schema does not support the values

New behavior: Discussed with OFI and agreed to populate start and end dates by mapping them to an existing element called `category_text`

# Additional Context
Include any additional context that may be relevant to the peer review process.

