### PR TITLE
map tribe_name to tribe_codes and send in ATP inbound to EA

### DIFF
--- a/lib/aca_entities/atp/functions/build_application.rb
+++ b/lib/aca_entities/atp/functions/build_application.rb
@@ -7,6 +7,7 @@ require 'aca_entities/atp/transformers/cv/income'
 require 'aca_entities/atp/transformers/cv/contact_info'
 require 'aca_entities/atp/transformers/cv/vlp_document'
 require "aca_entities/atp/functions/vlp_document_hash_builder"
+require "aca_entities/atp/functions/tribe_codes_builder"
 # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Layout/LineLength, Metrics/AbcSize, Metrics/ClassLength
 module AcaEntities
   module Atp
@@ -320,6 +321,8 @@ module AcaEntities
                                                  lawful_presence_status[:lawful_presence_status_eligibility][:eligibility_indicator] ? true : nil
                                                end
 
+          tribe_name = @tribal_augmentation[:person_tribe_name]
+          tribe_codes = AcaEntities::Atp::Functions::TribeCodesBuilder.new.call(tribe_name) if tribe_indicator
           {
             is_primary_applicant: @applicant_identifier == @primary_applicant_identifier,
             name: name_hash,
@@ -330,7 +333,8 @@ module AcaEntities
             native_american_information: nil,
             indian_tribe_member: tribe_indicator,
             tribal_state: tribe_indicator ? @tribal_augmentation[:location_state_us_postal_service_code] : nil,
-            tribal_name: tribe_indicator ? @tribal_augmentation[:person_tribe_name] : nil,
+            tribal_name: tribe_indicator ? tribe_name : nil,
+            tribe_codes: tribe_name.present? ? tribe_codes : nil,
             citizenship_immigration_status_information: @applicant_hash.nil? ? nil : citizenship_immigration_hash,
             eligible_immigration_status: lawful_presence_status_eligibility,
             is_consumer_role: true, # default value

--- a/lib/aca_entities/atp/functions/tribe_codes_builder.rb
+++ b/lib/aca_entities/atp/functions/tribe_codes_builder.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module AcaEntities
+  module Atp
+    module Functions
+
+      # build tribal codes based on tribal name
+      class TribeCodesBuilder
+        TRIBAL_CODES_MAPPING = {
+          "Maliseet" => "HM",
+          "Passamaquoddy" => "PD",
+          "Penobscot" => "PE",
+          "Micmac" => "AM"
+        }.freeze
+
+        def call(tribe_name)
+          find_codes(tribe_name)
+        end
+
+        def find_codes(tribe_name)
+          codes = []
+          TRIBAL_CODES_MAPPING.each do |key, code|
+            # Use a case-insensitive regex to match the key
+            codes << code if tribe_name =~ /#{Regexp.escape(key)}/i
+          end
+
+          codes.present? ? codes : ["OT"]
+        end
+      end
+    end
+  end
+end

--- a/lib/aca_entities/atp/transformers/cv/family.rb
+++ b/lib/aca_entities/atp/transformers/cv/family.rb
@@ -3,6 +3,7 @@
 require "aca_entities/atp/functions/address_builder"
 require "aca_entities/atp/functions/relationship_builder"
 require "aca_entities/atp/functions/vlp_document_hash_builder"
+require "aca_entities/atp/functions/tribe_codes_builder"
 require "aca_entities/atp/functions/lawful_presence_determination_builder"
 require "aca_entities/atp/functions/build_application"
 require "aca_entities/functions/age_on"
@@ -16,6 +17,7 @@ module AcaEntities
     module Transformers
       module Cv
         # Transformers implementation for atp payloads
+        # rubocop:disable Metrics/ClassLength
         class Family < ::AcaEntities::Operations::Transforms::Transform
           include ::AcaEntities::Operations::Transforms::Transformer
 
@@ -115,6 +117,16 @@ module AcaEntities
                     tribe_indicator = tribal_augmentation[:american_indian_or_alaska_native_indicator]
                     return nil unless tribe_indicator
                     tribal_augmentation[:person_tribe_name]
+                  }
+                  add_key 'person.person_demographics.tribe_codes', function: lambda { |v|
+                    tribal_augmentation = v.find(Regexp.new('record.people.*.tribal_augmentation')).map(&:item).last
+                    tribe_indicator = tribal_augmentation[:american_indian_or_alaska_native_indicator]
+                    return nil unless tribe_indicator
+
+                    tribe_name = tribal_augmentation[:person_tribe_name]
+                    return nil unless tribe_name
+
+                    AcaEntities::Atp::Functions::TribeCodesBuilder.new.call(tribe_name)
                   }
                   add_key 'person.person_demographics.indian_tribe_member', function: lambda { |v|
                     tribal_augmentation = v.find(Regexp.new('record.people.*.tribal_augmentation')).map(&:item).last
@@ -234,6 +246,7 @@ module AcaEntities
             end
           end
         end
+        # rubocop:enable Metrics/ClassLength
       end
     end
   end

--- a/spec/aca_entities/atp/transformers/person_ai_an_indicator_spec.rb
+++ b/spec/aca_entities/atp/transformers/person_ai_an_indicator_spec.rb
@@ -119,6 +119,17 @@ RSpec.describe AcaEntities::Atp, "given an inbound XML with person level PersonA
       expect(member[:person][:person_demographics][:tribal_name]).to eq "Eastern Band of Cherokee Indians of North Carolina"
     end
 
+    it "should set tribe_codes for person and applicant" do
+      applicant = @applicants.detect do |app|
+        app[:person_hbx_id] == "pe2000191"
+      end
+      member = @family_members.detect do |fm|
+        fm[:person][:person_name][:full_name].match(/Nancy/)
+      end
+      expect(applicant[:tribe_codes]).to eq ["OT"]
+      expect(member[:person][:person_demographics][:tribe_codes]).to eq ["OT"]
+    end
+
     it "should set tribal_state for person and applicant" do
       applicant = @applicants.detect do |app|
         app[:person_hbx_id] == "pe2000191"
@@ -183,6 +194,106 @@ RSpec.describe AcaEntities::Atp, "given an inbound XML with person level PersonA
       end
       expect(applicant[:tribal_state]).to eq nil
       expect(member[:person][:person_demographics][:tribal_state]).to eq nil
+    end
+  end
+
+  context "Tribe codes" do
+    let(:payload) do
+      File.read(Pathname.pwd.join("spec/support/atp/sample_payloads/sample_incarceration_payload.xml"))
+    end
+
+    let(:tribe_name) { "Eastern Band of Cherokee Indians of North Carolina" }
+
+    let(:document) do
+      document = Nokogiri::XML(payload)
+      path = document.xpath('//hix-core:PersonTribeName', 'hix-core' => "http://hix.cms.gov/0.1/hix-core")[0]
+      path.content = tribe_name
+      document
+    end
+
+    let(:account_transfer_request) do
+      ::AcaEntities::Serializers::Xml::Medicaid::Atp::AccountTransferRequest.parse(document.root.canonicalize, :single => true)
+    end
+
+    before do
+      @transformed = ::AcaEntities::Atp::Transformers::Cv::Family.transform(account_transfer_request.to_hash(identifier: true))
+      @applicants = @transformed[:family][:magi_medicaid_applications].first[:applicants]
+      @family_members = @transformed[:family][:family_members]
+    end
+
+    context "when Tribe is Penobscot" do
+      let(:tribe_name) { "Penobscot" }
+
+      it "should return valid tribe_codes for applicant and member" do
+        applicant = @applicants.detect do |app|
+          app[:person_hbx_id] == "pe2000191"
+        end
+        member = @family_members.detect do |fm|
+          fm[:person][:person_name][:full_name].match(/Nancy/)
+        end
+        expect(applicant[:tribe_codes]).to eq ["PE"]
+        expect(member[:person][:person_demographics][:tribe_codes]).to eq ["PE"]
+      end
+    end
+
+    context "when Tribe is Houlton Maliseets" do
+      let(:tribe_name) { "Houlton Maliseets" }
+
+      it "should return valid tribe_codes for applicant and member" do
+        applicant = @applicants.detect do |app|
+          app[:person_hbx_id] == "pe2000191"
+        end
+        member = @family_members.detect do |fm|
+          fm[:person][:person_name][:full_name].match(/Nancy/)
+        end
+        expect(applicant[:tribe_codes]).to eq ["HM"]
+        expect(member[:person][:person_demographics][:tribe_codes]).to eq ["HM"]
+      end
+    end
+
+    context "when Tribe is Aroostook Micmac" do
+      let(:tribe_name) { "Aroostook Micmac" }
+
+      it "should return valid tribe_codes for applicant and member" do
+        applicant = @applicants.detect do |app|
+          app[:person_hbx_id] == "pe2000191"
+        end
+        member = @family_members.detect do |fm|
+          fm[:person][:person_name][:full_name].match(/Nancy/)
+        end
+        expect(applicant[:tribe_codes]).to eq ["AM"]
+        expect(member[:person][:person_demographics][:tribe_codes]).to eq ["AM"]
+      end
+    end
+
+    context "when Tribe is Dana Point Passamaquoddy" do
+      let(:tribe_name) { "Dana Point Passamaquoddy" }
+
+      it "should return valid tribe_codes for applicant and member" do
+        applicant = @applicants.detect do |app|
+          app[:person_hbx_id] == "pe2000191"
+        end
+        member = @family_members.detect do |fm|
+          fm[:person][:person_name][:full_name].match(/Nancy/)
+        end
+        expect(applicant[:tribe_codes]).to eq ["PD"]
+        expect(member[:person][:person_demographics][:tribe_codes]).to eq ["PD"]
+      end
+    end
+
+    context "when Tribe is Pleasant Point Passamaquoddy" do
+      let(:tribe_name) { "Pleasant Point Passamaquoddy" }
+
+      it "should return valid tribe_codes for applicant and member" do
+        applicant = @applicants.detect do |app|
+          app[:person_hbx_id] == "pe2000191"
+        end
+        member = @family_members.detect do |fm|
+          fm[:person][:person_name][:full_name].match(/Nancy/)
+        end
+        expect(applicant[:tribe_codes]).to eq ["PD"]
+        expect(member[:person][:person_demographics][:tribe_codes]).to eq ["PD"]
+      end
     end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187861724

# A brief description of the changes

Current behavior: Tribe codes are not being sent to EA as part of ATP inbound process in ME

New behavior: Map Tribe name to Tribe codes and send to EA as part of ATP inbound process

# Additional Context
Include any additional context that may be relevant to the peer review process.

