### PR TITLE
Add updated logic for mapping of additional reasons.

### DIFF
--- a/lib/aca_entities/atp/xml/constraint/exchange/SBM_MESBM.xsd
+++ b/lib/aca_entities/atp/xml/constraint/exchange/SBM_MESBM.xsd
@@ -1,25 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>  
+<?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:exch="http://at.dsh.cms.gov/exchange/1.0"
-            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:hix-ee="http://hix.cms.gov/0.1/hix-ee"
-            xmlns:i="http://niem.gov/niem/appinfo/2.0"
-            xmlns:hix-types="http://hix.cms.gov/0.1/hix-types"
-            xmlns:s="http://niem.gov/niem/structures/2.0"
-            xmlns:me-atp="http://xmlns.coverme.gov/atp/hix-ee"
-            attributeFormDefault="qualified"
-            elementFormDefault="qualified" targetNamespace="http://xmlns.coverme.gov/atp/hix-ee" version="1">
-    <xsd:import namespace="http://hix.cms.gov/0.1/hix-types"
-                schemaLocation="../niem/domains/hix/0.1/hix-tupes/hix-types.xsd" />
-    <xsd:import namespace="http://hix.cms.gov/0.1/hix-ee"
-                schemaLocation="../niem/domains/hix/0.1/hix-ee/hix-ee.xsd" />
-   <xsd:import namespace="http://niem.gov/niem/structures/2.0"
-      schemaLocation="../../subset/niem/structures/2.0/structures.xsd"/>
-   
-    <xsd:element abstract="false" name="ReferralActivity"
-                 substitutionGroup="hix-ee:ReferralActivity"
-                 type="me-atp:ReferralActivityType">
-    </xsd:element>
-        
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   xmlns:hix-ee="http://hix.cms.gov/0.1/hix-ee"
+   xmlns:i="http://niem.gov/niem/appinfo/2.0"
+   xmlns:hix-types="http://hix.cms.gov/0.1/hix-types"
+   xmlns:s="http://niem.gov/niem/structures/2.0"
+   xmlns:me-atp="http://xmlns.coverme.gov/atp/hix-ee" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://xmlns.coverme.gov/atp/hix-ee" version="1">
+   <xsd:import namespace="http://hix.cms.gov/0.1/hix-types" schemaLocation="../niem/domains/hix/0.1/hix-tupes/hix-types.xsd" />
+   <xsd:import namespace="http://hix.cms.gov/0.1/hix-ee" schemaLocation="../niem/domains/hix/0.1/hix-ee/hix-ee.xsd" />
+   <xsd:import namespace="http://niem.gov/niem/structures/2.0" schemaLocation="../../subset/niem/structures/2.0/structures.xsd"/>
+
+   <xsd:element abstract="false" name="ReferralActivity" substitutionGroup="hix-ee:ReferralActivity" type="me-atp:ReferralActivityType">
+   </xsd:element>
+
    <xsd:complexType abstract="false" mixed="false" name="ReferralActivityType">
       <xsd:annotation>
          <xsd:appinfo>
@@ -35,6 +28,51 @@
          </xsd:extension>
       </xsd:complexContent>
    </xsd:complexType>
-   
-   <xsd:element name="AdditionalReferralActivityReasonCode" type="hix-types:ReferralActivityReasonCodeType" />
+
+   <xsd:simpleType name="AdditionalReferralActivityReasonCodeSimpleType">
+      <xsd:annotation>
+         <xsd:appinfo>
+            <i:Base i:name="Object" i:namespace="http://niem.gov/niem/structures/2.0"/>
+         </xsd:appinfo>
+         <xsd:documentation source="">A data type for a reason for a referral activity.</xsd:documentation>
+      </xsd:annotation>
+      <xsd:restriction base="xsd:token">
+         <xsd:enumeration value="FullDetermination">
+            <xsd:annotation>
+               <xsd:documentation source="">The applicant has requested a full determination be made for Medicaid and Children's Health Insurance Program eligibility.</xsd:documentation>
+            </xsd:annotation>
+         </xsd:enumeration>
+         <xsd:enumeration value="WaitingPeriodException">
+            <xsd:annotation>
+               <xsd:documentation source="">The marketplace has requested that a Children's Health Insurance Program (CHIP) system determine if an applicant qualifies for an exception to the normal waiting period rules for the Children's Health Insurance Program. (This reason can apply either in the case of an initial referral from a marketplace to a CHIP system or in the case of a rejected referral initiated by a CHIP system.)</xsd:documentation>
+            </xsd:annotation>
+         </xsd:enumeration>
+         <xsd:enumeration value="GapFilling">
+            <xsd:annotation>
+               <xsd:documentation source="">The sender is referring an applicant under the gap filling rules established by the Centers for Medicare &amp; Medicaid Services.</xsd:documentation>
+            </xsd:annotation>
+         </xsd:enumeration>
+         <xsd:enumeration value="Renewal">
+            <xsd:annotation>
+               <xsd:documentation source="">The sender is referring an applicant under a renewal application.</xsd:documentation>
+            </xsd:annotation>
+         </xsd:enumeration>
+      </xsd:restriction>
+   </xsd:simpleType>
+
+   <xsd:complexType name="AdditionalReferralActivityReasonCodeType">
+      <xsd:annotation>
+         <xsd:appinfo>
+            <i:Base i:name="Object" i:namespace="http://niem.gov/niem/structures/2.0"/>
+         </xsd:appinfo>
+         <xsd:documentation source="">A data type for an additional reason for a referral activity.</xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="me-atp:AdditionalReferralActivityReasonCodeSimpleType">
+            <xsd:attributeGroup ref="s:SimpleObjectAttributeGroup"/>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+
+   <xsd:element name="AdditionalReferralActivityReasonCode" type="me-atp:AdditionalReferralActivityReasonCodeType" />
 </xsd:schema>

--- a/lib/aca_entities/medicaid/contracts/account_transfer_request_contract.rb
+++ b/lib/aca_entities/medicaid/contracts/account_transfer_request_contract.rb
@@ -13,7 +13,6 @@ module AcaEntities
           required(:people).array(:hash)
           required(:senders).filled(:array)
           required(:receivers).filled(:array)
-          required(:insurance_application).filled(:hash)
           optional(:medicaid_households).array(:hash)
           optional(:assister).maybe(:hash)
           optional(:authorized_representative).maybe(:hash)

--- a/lib/aca_entities/serializers/xml/medicaid/atp/additional_referral_activity.rb
+++ b/lib/aca_entities/serializers/xml/medicaid/atp/additional_referral_activity.rb
@@ -26,8 +26,10 @@ module AcaEntities
             has_one :receiver_reference, ReferralActivityReceiverReference
             has_one :status, ReferralActivityStatus
             element :reason_code, String, tag: 'ReferralActivityReasonCode', namespace: "hix-ee"
-            has_many :additional_reason_codes, String, tag: 'AdditionalReferralActivityReasonCode', namespace: 'me-atp'
             has_many :eligibility_reason_reference, ReferralActivityEligibilityReasonReference
+
+            # As this is derived by extension, new elements must come last.
+            has_many :additional_reason_codes, String, tag: 'AdditionalReferralActivityReasonCode', namespace: 'me-atp'
 
             def self.domain_to_mapper(referral_activity)
               mapper = self.new
@@ -37,9 +39,8 @@ module AcaEntities
               mapper.receiver_reference = ReferralActivityReceiverReference.domain_to_mapper(referral_activity.receiver_reference)
               mapper.status = ReferralActivityStatus.domain_to_mapper(referral_activity.status)
               other_reason_codes = referral_activity.additional_reason_codes || []
-              encoded_additional_reasons = other_reason_codes - [referral_activity.reason_code]
-              mapper.reason_code = referral_activity.reason_code
-              mapper.additional_reason_codes = encoded_additional_reasons
+              mapper.reason_code = referral_activity.reason_code unless referral_activity.reason_code.blank?
+              mapper.additional_reason_codes = other_reason_codes
               mapper
             end
 

--- a/lib/aca_entities/serializers/xml/medicaid/atp/insurance_applicant.rb
+++ b/lib/aca_entities/serializers/xml/medicaid/atp/insurance_applicant.rb
@@ -187,10 +187,10 @@ module AcaEntities
             def self.encode_ref_activity(mapper, ref_activity)
               return unless ref_activity
 
-              if ref_activity.additional_reason_codes.present? && ref_activity.additional_reason_codes.any?
-                mapper.additional_referral_activity = AdditionalReferralActivity.domain_to_mapper(ref_activity)
-              else
+              if ref_activity.additional_reason_codes.nil?
                 mapper.referral_activity = ReferralActivity.domain_to_mapper(ref_activity)
+              else
+                mapper.additional_referral_activity = AdditionalReferralActivity.domain_to_mapper(ref_activity)
               end
             end
           end

--- a/lib/aca_entities/serializers/xml/medicaid/atp/referral_activity.rb
+++ b/lib/aca_entities/serializers/xml/medicaid/atp/referral_activity.rb
@@ -32,7 +32,7 @@ module AcaEntities
               mapper.sender_reference = ReferralActivitySenderReference.domain_to_mapper(referral_activity.sender_reference)
               mapper.receiver_reference = ReferralActivityReceiverReference.domain_to_mapper(referral_activity.receiver_reference)
               mapper.status = ReferralActivityStatus.domain_to_mapper(referral_activity.status)
-              mapper.reason_code = referral_activity.reason_code
+              mapper.reason_code = referral_activity.reason_code unless referral_activity.reason_code.blank?
               mapper
             end
 

--- a/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
+++ b/spec/aca_entities/atp/operations/aces/generate_xml_spec.rb
@@ -75,12 +75,12 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml  do
       expect(texts&.first&.content&.strip).to eq "true"
     end
 
-    it 'should include the default referral activity reason code' do
+    it 'should not include any default activity code' do
       payload_hash[:family][:magi_medicaid_applications][:applicants].first[:is_temporarily_out_of_state] = true
       result = described_class.new.call(payload_hash.to_json)
       doc = Nokogiri::XML.parse(result.value!)
       texts = doc.xpath("//hix-ee:InsuranceApplicant/hix-ee:ReferralActivity/hix-ee:ReferralActivityReasonCode", namespaces).map(&:content)
-      expect(texts).to eq ["FullDetermination", "FullDetermination", "FullDetermination"]
+      expect(texts).to eq []
     end
 
     context 'when person has contact with unmappable kind' do
@@ -1078,11 +1078,11 @@ RSpec.describe AcaEntities::Atp::Operations::Aces::GenerateXml, "given a multipl
   let(:payload) { File.read(Pathname.pwd.join("spec/support/atp/sample_payloads/multiple_reason_L_cv_payload.json")) }
   let(:payload_hash) { JSON.parse(payload, symbolize_names: true) }
 
-  it 'should include additional referral activity reason codes, excluding the primary one' do
+  it 'should include additional referral activity reason codes' do
     payload_hash[:family][:magi_medicaid_applications][:applicants].first[:is_temporarily_out_of_state] = true
     result = described_class.new.call(payload_hash.to_json)
     doc = Nokogiri::XML.parse(result.value!)
     texts = doc.xpath("//hix-ee:InsuranceApplicant/me-atp:ReferralActivity/me-atp:AdditionalReferralActivityReasonCode", namespaces).map(&:content)
-    expect(texts).to eq ["GapFilling"]
+    expect(texts).to eq ["FullDetermination", "GapFilling"]
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [X] For all UI changes, there is cucumber coverage
- [X] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [X] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [X] There are no inline styles added
- [X] There are no inline javascript added
- [X] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [X] Code does not use .html_safe
- [X] All images added/updated have alt text
- [X] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [X] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188151062

# A brief description of the changes

Current behavior: Currently aca_entities does not encode additional reasons correctly.

New behavior:  Additional reasons should now be encoded correctly.