### PR TITLE
fix citizenship/naturalization number vlp document import issues

### DIFF
--- a/lib/aca_entities/atp/functions/vlp_document_hash_builder.rb
+++ b/lib/aca_entities/atp/functions/vlp_document_hash_builder.rb
@@ -60,6 +60,8 @@ module AcaEntities
             vlp_document[:card_number] = vlp_document[:document_numbers]&.first&.dig(:identification_id).to_s
           elsif vlp_document[:category_code] == "Certificate of Citizenship"
             vlp_document[:citizenship_number] = vlp_document[:document_numbers]&.first&.dig(:identification_id).to_s
+          elsif vlp_document[:category_code] == "Naturalization Certificate"
+            vlp_document[:naturalization_number] = vlp_document[:document_numbers]&.first&.dig(:identification_id).to_s
           end
 
           # this handles whether the expiration date returned is a date inside a hash or null
@@ -91,6 +93,10 @@ module AcaEntities
             vlp_document[:sevis_id] = document_person_id[:identification_id]
           when 'Visa Number'
             vlp_document[:visa_number] = document_person_id[:identification_id]
+          when /certificate\s*of\s*citizenship/i
+            vlp_document[:citizenship_number] = document_person_id[:identification_id]
+          when /naturalization\s*certificate\s*number/i
+            vlp_document[:naturalization_number] = document_person_id[:identification_id]
           end
         end
 

--- a/lib/aca_entities/atp/functions/vlp_document_hash_builder.rb
+++ b/lib/aca_entities/atp/functions/vlp_document_hash_builder.rb
@@ -80,6 +80,10 @@ module AcaEntities
         end
 
         # this method handles the identification category text and maps it to the correct key in the vlp_document hash
+        # Being flexible and extra cautious with case insensitive match for sevis id/ cert of citizenship/naturalization number
+        # as we are unsure in which string case external system  will be sending the document category text.
+        # The issue first occurred with the Sevis ID in DC client,
+        # as sometimes DC sends it as Sevis ID, and other times as sevis id.
         def handle_identification_category(vlp_document, document_person_id)
           case document_person_id[:identification_category_text]
           when 'Alien Number'

--- a/spec/aca_entities/atp/functions/vlp_document_hash_builder_spec.rb
+++ b/spec/aca_entities/atp/functions/vlp_document_hash_builder_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe AcaEntities::Atp::Functions::VlpDocumentHashBuilder do
     }
   end
 
+  let(:naturalization_certificate_2) do
+    {
+      category_code: 'NaturalizationCertificate',
+      document_person_ids: [
+        {
+          identification_category_text: 'Alien Number',
+          identification_id: '123456789'
+        },
+        {
+          identification_category_text: 'Naturalization Certificate Number',
+          identification_id: '123456789'
+        }
+      ],
+      expiration_date: {
+        date: '2022-12-31'
+      }
+    }
+  end
+
   let(:document_citizenship) do
     {
       category_code: 'Certificate of Citizenship',
@@ -37,6 +56,25 @@ RSpec.describe AcaEntities::Atp::Functions::VlpDocumentHashBuilder do
       document_numbers: [
         {
           identification_id: '987654321'
+        }
+      ],
+      expiration_date: {
+        date: '2022-12-31'
+      }
+    }
+  end
+
+  let(:document_citizenship_2) do
+    {
+      category_code: 'Certificate of Citizenship',
+      document_person_ids: [
+        {
+          identification_category_text: 'Alien Number',
+          identification_id: '123456789'
+        },
+        {
+          identification_category_text: 'certificate of citizenship',
+          identification_id: '123456789'
         }
       ],
       expiration_date: {
@@ -72,6 +110,29 @@ RSpec.describe AcaEntities::Atp::Functions::VlpDocumentHashBuilder do
         expect(result[:category_code]).to eq('Naturalization Certificate')
         expect(result[:alien_number]).to eq('123456789')
         expect(result[:naturalization_certificate]).to eq('987654321')
+        expect(result[:naturalization_number]).to eq('987654321')
+        expect(result[:expiration_date]).to eq('2022-12-31')
+        expect(result[:card_number]).to be_nil
+      end
+    end
+
+    context 'with a document person id that is a naturalization certificate' do
+      it 'returns a hash with updated document information' do
+        result = builder.call(naturalization_certificate_2)
+        expect(result[:category_code]).to eq('Naturalization Certificate')
+        expect(result[:alien_number]).to eq('123456789')
+        expect(result[:naturalization_number]).to eq('123456789')
+        expect(result[:expiration_date]).to eq('2022-12-31')
+        expect(result[:card_number]).to be_nil
+      end
+    end
+
+    context 'with a document person id that is a certificate of citizenship' do
+      it 'returns a hash with updated document information' do
+        result = builder.call(document_citizenship_2)
+        expect(result[:category_code]).to eq('Certificate of Citizenship')
+        expect(result[:alien_number]).to eq('123456789')
+        expect(result[:citizenship_number]).to eq('123456789')
         expect(result[:expiration_date]).to eq('2022-12-31')
         expect(result[:card_number]).to be_nil
       end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187861725

Issue: https://www.pivotaltracker.com/story/show/187861725/comments/242275863

# A brief description of the changes

Current behavior: Certificate/Naturalization numbers are not being sent to EA during the ATP inbound process as the mapping for those number types is missing.

New behavior: Map Certificate/Naturalization number mapping in ATP inbound Process

# Additional Context
Include any additional context that may be relevant to the peer review process.

