### PR TITLE
fix card number issue in ATP inbound VLP mapping

### DIFF
--- a/lib/aca_entities/atp/functions/vlp_document_hash_builder.rb
+++ b/lib/aca_entities/atp/functions/vlp_document_hash_builder.rb
@@ -101,6 +101,8 @@ module AcaEntities
             vlp_document[:citizenship_number] = document_person_id[:identification_id]
           when /naturalization\s*certificate\s*number/i
             vlp_document[:naturalization_number] = document_person_id[:identification_id]
+          when /card\s*number/i
+            vlp_document[:card_number] = document_person_id[:identification_id]
           end
         end
 

--- a/spec/aca_entities/atp/functions/vlp_document_hash_builder_spec.rb
+++ b/spec/aca_entities/atp/functions/vlp_document_hash_builder_spec.rb
@@ -103,6 +103,25 @@ RSpec.describe AcaEntities::Atp::Functions::VlpDocumentHashBuilder do
     }
   end
 
+  let(:document_i766) do
+    {
+      category_code: 'I766',
+      document_person_ids: [
+        {
+          identification_category_text: 'Alien Number',
+          identification_id: '123456789'
+        },
+        {
+          identification_category_text: 'Card Number',
+          identification_id: '123456789'
+        }
+      ],
+      expiration_date: {
+        date: '2022-12-31'
+      }
+    }
+  end
+
   describe '#call' do
     context 'with a document that is a naturalization certificate' do
       it 'returns a hash with updated document information' do
@@ -157,6 +176,16 @@ RSpec.describe AcaEntities::Atp::Functions::VlpDocumentHashBuilder do
         expect(result[:alien_number]).to eq('123456789')
         expect(result[:expiration_date]).to eq('2022-12-31')
         expect(result[:card_number]).to eq('AAA0000000000')
+      end
+    end
+
+    context 'with a document that is an I-766' do
+      it 'returns a hash with updated document information' do
+        result = builder.call(document_i766)
+        expect(result[:category_code]).to eq('I-766 (Employment Authorization Card)')
+        expect(result[:alien_number]).to eq('123456789')
+        expect(result[:expiration_date]).to eq('2022-12-31')
+        expect(result[:card_number]).to eq('123456789')
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640057/stories/187861725/comments/242353474

# A brief description of the changes

Current behavior: Card Number is not being sent to EA if ATP inbound payload contains card number

New behavior: Map Card number to VLP document in ATP inbound process and send that value to EA

# Additional Context
Include any additional context that may be relevant to the peer review process.

